### PR TITLE
MAE-432: Adding import API endpoint and Recurring Contributions Importer

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs linter
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+
+      - name: Build Drupal site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.28.3
+          path: site/web/sites/all/modules/civicrm
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextrasimporterapi
+
+      - name: Installing Membershipextras Importer API extension and its dependencies
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
+          git clone --depth 1 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
+          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
+
+      - name: Run phpunit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextrasimporterapi
+        run: phpunit5

--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -1,0 +1,45 @@
+<?php
+
+class CRM_Membershipextrasimporterapi_CSVRowImporter {
+
+  private $rowData;
+
+  private $contactId;
+
+  public function __construct($rowData) {
+    $this->rowData = $rowData;
+    $this->contactId = $this->getContactId();
+  }
+
+  public function import() {
+    $recurContributionImporter = new CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution($this->rowData, $this->contactId);
+    $recurContributionId = $recurContributionImporter->import();
+  }
+
+  private function getContactId() {
+    $contactId = NULL;
+
+    if (!empty($this->rowData['contact_id'])) {
+      $sqlQuery = "SELECT id FROM civicrm_contact WHERE id = %1";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contact_id'], 'Integer']]);
+      if (!$result->fetch()) {
+        throw new CRM_Membershipextrasimporterapi_Exception_InvalidContactException("Cannot find contact with Id = $this->rowData['contact_id']", 100);
+      }
+
+      return $result->id;
+    }
+
+    if (!empty($this->rowData['contact_external_id'])) {
+      $sqlQuery = "SELECT id FROM civicrm_contact WHERE external_identifier = %1";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contact_external_id'], 'String']]);
+      if (!$result->fetch()) {
+        throw new CRM_Membershipextrasimporterapi_Exception_InvalidContactException("Cannot find contact with External Id = $this->rowData['contact_external_id']", 200);
+      }
+
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidContactException('Either Contact Id or Contact External Id is required.', 300);
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Imports the recurring contribution record.
+ *
+ * Class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
+
+  private $rowData;
+
+  private $contactId;
+
+  public function __construct($rowData, $contactId) {
+    $this->rowData = $rowData;
+    $this->contactId = $contactId;
+  }
+
+  public function import() {
+    $recurContributionId = $this->getRecurContributionIdIfExist();
+    if ($recurContributionId) {
+      return $recurContributionId;
+    }
+
+    $sqlParams = $this->prepareSqlParams();
+    $sqlQuery = "INSERT INTO `civicrm_contribution_recur` (`contact_id` , `amount` , `currency` , `frequency_unit` , `frequency_interval` , `installments` ,
+            `start_date`, `contribution_status_id`, `payment_processor_id` , `financial_type_id` , `payment_instrument_id`, `auto_renew`, `create_date`,
+            `next_sched_contribution_date`, `cycle_day`) 
+            VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9 ,%10, %11, %12, %13, %14, %15)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as recur_contribution_id');
+    $dao->fetch();
+    $recurContributionId = $dao->recur_contribution_id;
+
+    $sqlQuery = "INSERT INTO `civicrm_value_contribution_recur_ext_id` (`entity_id` , `external_id`) 
+           VALUES ({$recurContributionId}, %1)";
+    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
+
+    return $recurContributionId;
+  }
+
+  private function getRecurContributionIdIfExist() {
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_contribution_recur_ext_id WHERE external_id = %1";
+    $recurContributionId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
+    $recurContributionId->fetch();
+
+    if (!empty($recurContributionId->id)) {
+      return $recurContributionId->id;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Prepares the sql parameters
+   * that will be used to create recur
+   * contribution record.
+   *
+   * @return array
+   *
+   * @throws CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException
+   */
+  private function prepareSqlParams() {
+    $amount = $this->getAmount();
+    $currency = $this->getCurrency();
+    $frequencyParams = $this->calculateFrequencyParameters();
+    $recurContributionStatusId = $this->getRecurContributionStatusId();
+    $paymentProcessorId = $this->getPaymentProcessorId();
+    $financialTypeId = $this->getFinancialTypeId();
+    $paymentMethodId = $this->getPaymentMethodId();
+    $isAutoRenew = $this->isAutoRenew();
+    $cycleDay = $this->getCycleDay($frequencyParams['unit']);
+    $startDate = $this->formatRowDate('payment_plan_start_date', 'Start Date');
+    $createDate = $this->formatRowDate('payment_plan_create_date', 'Create Date');
+    $nextContributionDate = $this->formatRowDate('payment_plan_next_contribution_date', 'Next Contribution Date', TRUE);
+
+    return [
+      1 => [$this->contactId, 'Integer'],
+      2 => [$amount, 'Money'],
+      3 => [$currency, 'String'],
+      4 => [$frequencyParams['unit'], 'String'],
+      5 => [$frequencyParams['interval'], 'Integer'],
+      6 => [$frequencyParams['installments_count'], 'Integer'],
+      7 => [$startDate, 'String'],
+      8 => [(int) $recurContributionStatusId, 'Integer'],
+      9 => [(int) $paymentProcessorId, 'Integer'],
+      10 => [(int) $financialTypeId, 'Integer'],
+      11 => [(int) $paymentMethodId, 'Integer'],
+      12 => [$isAutoRenew, 'Integer'],
+      13 => [$createDate, 'String'],
+      14 => [$nextContributionDate, 'String'],
+      15 => [(int) $cycleDay, 'Integer'],
+    ];
+  }
+
+  private function getAmount() {
+    if (!empty($this->rowData['payment_plan_total_amount'])) {
+      $amount = $this->rowData['payment_plan_total_amount'];
+    }
+    else {
+      // todo : if null we default this to the total amount of the instalment with the most future date. but how to do that ?
+    }
+
+    return $amount;
+  }
+
+  private function getCurrency() {
+    // todo : not in mapping document, need to discuss with others how to get it.
+    return 'GBP';
+  }
+
+  private function calculateFrequencyParameters() {
+    switch ($this->rowData['payment_plan_frequency']) {
+      case 'month':
+        $frequencyParameters['unit'] = 'month';
+        $frequencyParameters['interval'] = 1;
+        $frequencyParameters['installments_count'] = 12;
+        break;
+
+      case 'year':
+        $frequencyParameters['unit'] = 'year';
+        $frequencyParameters['interval'] = 1;
+        $frequencyParameters['installments_count'] = 1;
+        break;
+
+      default:
+        throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Payment Plan Frequency should be either "month" or "year"', 100);
+    }
+
+    return $frequencyParameters;
+  }
+
+  private function getRecurContributionStatusId() {
+    $statusName = 'Completed';
+    if (!empty($this->rowData['payment_plan_status'])) {
+      $statusName = $this->rowData['payment_plan_status'];
+    }
+
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'contribution_recur_status' AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$statusName, 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Invalid payment plan "Status"', 200);
+  }
+
+  private function getPaymentProcessorId() {
+    // todo: later to add validation to ensure that direct debit fields exist if the payment processor is 'direct debit'.
+    $sqlQuery = "SELECT id FROM civicrm_payment_processor WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_payment_processor'], 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Invalid payment plan "Payment Processor"', 300);
+  }
+
+  private function getFinancialTypeId() {
+    $sqlQuery = "SELECT id FROM civicrm_financial_type WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_financial_type'], 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Invalid payment plan "Financial Type"', 400);
+  }
+
+  private function getPaymentMethodId() {
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'payment_instrument'  AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_payment_method'], 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Incorrect Invalid payment plan "Payment Method"', 500);
+  }
+
+  private function isAutoRenew() {
+    $autoRenew = 0;
+    if (!empty($this->rowData['payment_plan_auto_renew']) && $this->rowData['payment_plan_auto_renew'] == 1) {
+      $autoRenew = 1;
+    }
+
+    return $autoRenew;
+  }
+
+  private function getCycleDay($frequencyUnit) {
+    if ($frequencyUnit == 'year') {
+      return NULL;
+    }
+
+    if ($frequencyUnit == 'month' && empty($this->rowData['payment_plan_cycle_day'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Cycle day is required field for monthly payment plans', 600);
+    }
+
+    if ($frequencyUnit == 'month' && ($this->rowData['payment_plan_cycle_day'] < 1 || $this->rowData['payment_plan_cycle_day'] >= 28)) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Payment Plan Cycle day must be positive integer that is less than 28', 700);
+    }
+
+    return $this->rowData['payment_plan_cycle_day'];
+  }
+
+  private function formatRowDate($dateColumnName, $columnLabel, $isRequired = FALSE) {
+    if ($isRequired && empty($this->rowData[$dateColumnName])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException("Payment Plan '{$columnLabel}' is required field.", 800);
+    }
+
+    if (!empty($this->rowData[$dateColumnName])) {
+      $date = DateTime::createFromFormat('YmdHis', $this->rowData[$dateColumnName]);
+      $date = $date->format('Y-m-d');
+    }
+    else {
+      $date = new DateTime();
+      $date = $date->format('Y-m-d');
+    }
+
+    return $date;
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/Exception/InvalidContactException.php
+++ b/CRM/Membershipextrasimporterapi/Exception/InvalidContactException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_Membershipextrasimporterapi_Exception_InvalidContactException extends Exception {}

--- a/CRM/Membershipextrasimporterapi/Exception/InvalidRecurContributionFieldException.php
+++ b/CRM/Membershipextrasimporterapi/Exception/InvalidRecurContributionFieldException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException extends Exception {}

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -1,13 +1,18 @@
 <?php
 
-function civicrm_api3_membershipextras_importer_import($params) {
-  return civicrm_api3_create_success(
-    true,
-    []
-  );
+function civicrm_api3_membershipextras_importer_create($params) {
+  try {
+    $importer = new CRM_Membershipextrasimporterapi_CSVRowImporter($params);
+    $importer->import();
+  }
+  catch (Exception $exception) {
+    return civicrm_api3_create_error($exception->getMessage());
+  }
+
+  return civicrm_api3_create_success(1, $params);
 }
 
-function _civicrm_api3_membershipextras_importer_import_spec(&$params) {
+function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
   $params['contact_id'] = [
     'title' => 'Contact Id',
     'type' => CRM_Utils_Type::T_INT,
@@ -58,7 +63,7 @@ function _civicrm_api3_membershipextras_importer_import_spec(&$params) {
   ];
 
   $params['payment_plan_cycle_day'] = [
-    'title' => 'Payment Plan Create Date',
+    'title' => 'Payment Plan Cycle Day',
     'type' => CRM_Utils_Type::T_INT,
   ];
 
@@ -77,4 +82,11 @@ function _civicrm_api3_membershipextras_importer_import_spec(&$params) {
     'title' => 'Payment Plan Status',
     'type' => CRM_Utils_Type::T_STRING,
   ];
+
+  $params['payment_plan_payment_method'] = [
+    'title' => 'Payment Plan Payment Method',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
 }

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -1,0 +1,80 @@
+<?php
+
+function civicrm_api3_membershipextras_importer_import($params) {
+  return civicrm_api3_create_success(
+    true,
+    []
+  );
+}
+
+function _civicrm_api3_membershipextras_importer_import_spec(&$params) {
+  $params['contact_id'] = [
+    'title' => 'Contact Id',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $params['contact_external_id'] = [
+    'title' => 'Contact External Id',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['payment_plan_external_id'] = [
+    'title' => 'Payment Plan External Id',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['payment_plan_payment_processor'] = [
+    'title' => 'Payment Plan Payment Processor',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['payment_plan_total_amount'] = [
+    'title' => 'Payment Plan Total Amount',
+    'type' => CRM_Utils_Type::T_MONEY,
+  ];
+
+  $params['payment_plan_frequency'] = [
+    'title' => 'Payment Plan Frequency',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['payment_plan_next_contribution_date'] = [
+    'title' => 'Payment Plan Next Contribution Date',
+    'type' => CRM_Utils_Type::T_DATE,
+    'api.required' => 1,
+  ];
+
+  $params['payment_plan_start_date'] = [
+    'title' => 'Payment Plan Start Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['payment_plan_create_date'] = [
+    'title' => 'Payment Plan Create Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['payment_plan_cycle_day'] = [
+    'title' => 'Payment Plan Create Date',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $params['payment_plan_auto_renew'] = [
+    'title' => 'Payment Plan Auto Renew?',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $params['payment_plan_financial_type'] = [
+    'title' => 'Payment Plan Financial Type',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['payment_plan_status'] = [
+    'title' => 'Payment Plan Status',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Download PHPCS if it does not exist
+if [ ! -f phpcs.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+fi
+# Give executable permission to PHPCS
+chmod +x phpcs.phar
+
+# Download PHPCBF if it does not exist
+if [ ! -f phpcbf.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+fi
+
+# Give executable permission to PHPCBF
+chmod +x phpcbf.phar
+
+# Clone CiviCRM Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
+fi

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="PHP Custom Ruleset">
+  <description>CiviCRM Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal"></rule>
+  <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+  <exclude-pattern>membershipextrasimporterapi.civix.php</exclude-pattern>
+  <exclude-pattern>CRM/Membershipextrasimporterapi/Upgrader/Base.php</exclude-pattern>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  /**
+   * Sets up Headless, use stock schema,, install extensions.
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.membershipextras')
+      ->install('uk.co.compucorp.manualdirectdebit')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -1,0 +1,463 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution as RecurContributionImporter;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * @group headless
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest extends BaseHeadlessTest {
+
+  private $sampleRowData = [
+    'payment_plan_external_id' => 'test1',
+    'payment_plan_payment_processor' => 'Offline Recurring Contribution',
+    'payment_plan_total_amount' => 50,
+    'payment_plan_frequency' => 'month',
+    'payment_plan_next_contribution_date' => '20210101000000',
+    'payment_plan_start_date' => '20200101000000',
+    'payment_plan_create_date' => '20190101000000',
+    'payment_plan_cycle_day' => 15,
+    'payment_plan_auto_renew' => 0,
+    'payment_plan_financial_type' => 'Member Dues',
+    'payment_plan_payment_method' => 'EFT',
+    'payment_plan_status' => 'Pending',
+  ];
+
+  private $contactId;
+
+  public function setUp() {
+    $this->contactId = ContactFabricator::fabricate()['id'];
+  }
+
+  public function testImportNewRecurContribution() {
+    $beforeImportIds = $this->getRecurContributionsByContactId($this->contactId);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $afterImportIds = $this->getRecurContributionsByContactId($this->contactId);
+
+    $importSucceed = FALSE;
+    if (empty($beforeImportIds) && $afterImportIds[0] == $newRecurContributionId) {
+      $importSucceed = TRUE;
+    }
+
+    $this->assertTrue($importSucceed);
+  }
+
+  public function testImportExistingRecurContributionWillNotCreateNewOne() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test2';
+
+    $firstImport = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $firstRecurContributionId = $firstImport->import();
+
+    $secondImport = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $secondRecurContributionId = $secondImport->import();
+
+    $this->assertEquals($firstRecurContributionId, $secondRecurContributionId);
+  }
+
+  public function testImportWillCreateExternalIdCustomFieldRecord() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test3';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_contribution_recur_ext_id WHERE external_id = %1 AND entity_id = {$newRecurContributionId}";
+    $recurContributionId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->sampleRowData['payment_plan_external_id'], 'String']]);
+    $recurContributionId->fetch();
+
+    $this->assertEquals(1, $recurContributionId->N);
+  }
+
+  public function testImportWillSetCorrectAmountValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test4';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+    $this->assertEquals($this->sampleRowData['payment_plan_total_amount'], $newRecurContribution['amount']);
+  }
+
+  public function testImportMonthlyRecurContributionWillSetCorrectFrequencyInformation() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test5';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $correctFrequencyInformation = ($newRecurContribution['frequency_unit'] == 'month') && ($newRecurContribution['frequency_interval'] == 1) && ($newRecurContribution['installments'] == 12);
+    $this->assertTrue($correctFrequencyInformation);
+  }
+
+  public function testImportYearlyRecurContributionWillSetCorrectFrequencyInformation() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test6';
+    $this->sampleRowData['payment_plan_frequency'] = 'year';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $correctFrequencyInformation = ($newRecurContribution['frequency_unit'] == 'year') && ($newRecurContribution['frequency_interval'] == 1) && ($newRecurContribution['installments'] == 1);
+    $this->assertTrue($correctFrequencyInformation);
+  }
+
+  public function testImportWithIncorrectFrequencyWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test7';
+    $this->sampleRowData['payment_plan_frequency'] = 'week';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(100);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWithNoStatusWillDefaultToCompleted() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test8';
+    unset($this->sampleRowData['payment_plan_status']);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $completedRecurContributionStatusId = $this->getRecurContributionStatusId('Completed');
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($completedRecurContributionStatusId, $newRecurContribution['contribution_status_id']);
+  }
+
+  public function testImportWillSetCorrectStatusValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test9';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $recurContributionStatusId = $this->getRecurContributionStatusId($this->sampleRowData['payment_plan_status']);
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($recurContributionStatusId, $newRecurContribution['contribution_status_id']);
+  }
+
+  public function testImportWithIncorrectStatusWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test10';
+    $this->sampleRowData['payment_plan_status'] = 'invalid-status';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(200);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWillSetCorrectPaymentProcessorValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test11';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $recurContributionPPId = $this->getRecurContributionPaymentProcessorId($this->sampleRowData['payment_plan_payment_processor']);
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($recurContributionPPId, $newRecurContribution['payment_processor_id']);
+  }
+
+  public function testImportWithIncorrectPaymentProcessorWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test12';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'invalid-pp';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(300);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWillSetCorrectFinancialTypeValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test13';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $recurContributionFTId = $this->getRecurContributionFinancialTypeId($this->sampleRowData['payment_plan_financial_type']);
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($recurContributionFTId, $newRecurContribution['financial_type_id']);
+  }
+
+  public function testImportWithIncorrectFinancialTypeWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test14';
+    $this->sampleRowData['payment_plan_financial_type'] = 'invalid-ft';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(400);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWillSetCorrectPaymentMethodValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test15';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $recurContributionPMId = $this->getRecurContributionPaymentMethodId($this->sampleRowData['payment_plan_payment_method']);
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($recurContributionPMId, $newRecurContribution['payment_instrument_id']);
+  }
+
+  public function testImportWithIncorrectPaymentMethodWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test16';
+    $this->sampleRowData['payment_plan_payment_method'] = 'invalid-pm';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(500);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWillDefaultToNonAutoRenewalRecurContribution() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test17';
+    unset($this->sampleRowData['payment_plan_auto_renew']);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals(0, $newRecurContribution['auto_renew']);
+  }
+
+  public function testImportWithAutoRenewalOnWillSetCorrectAutoRenewValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test18';
+    $this->sampleRowData['payment_plan_auto_renew'] = 1;
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals(1, $newRecurContribution['auto_renew']);
+  }
+
+  public function testImportYearlyRecurContributionWillNotSetCycleDay() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test19';
+    $this->sampleRowData['payment_plan_frequency'] = 'year';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEmpty($newRecurContribution['cycle_day']);
+  }
+
+  public function testImportMonthlyRecurContributionWithNoCycleDayWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test20';
+    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    unset($this->sampleRowData['payment_plan_cycle_day']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(600);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportMonthlyRecurContributionWithCycleDayLessThanOneWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test21';
+    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_cycle_day'] = -1;
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(700);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportMonthlyRecurContributionWithCycleDayEqual28WillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test22';
+    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_cycle_day'] = 28;
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(700);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportMonthlyRecurContributionWithCycleDayLargerThan28WillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test23';
+    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_cycle_day'] = 29;
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(700);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportMonthlyRecurContributionWillSetCorrectCycleDayValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test24';
+    $this->sampleRowData['payment_plan_frequency'] = 'month';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($this->sampleRowData['payment_plan_cycle_day'], $newRecurContribution['cycle_day']);
+  }
+
+  public function testImportWillSetCorrectStartDateValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test25';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['payment_plan_start_date']);
+    $expectedDate = $expectedDate->format('Y-m-d H:i:s');
+
+    $this->assertEquals($expectedDate, $newRecurContribution['start_date']);
+  }
+
+  public function testImportWithNoStartDateWillDefaultToTodayDate() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test26';
+    unset($this->sampleRowData['payment_plan_start_date']);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $expectedDate = new DateTime();
+    $expectedDate = $expectedDate->format('Y-m-d');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d H:i:s', $newRecurContribution['start_date']);
+    $storedDate = $storedDate->format('Y-m-d');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportWillSetCorrectCreateDateValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test27';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['payment_plan_create_date']);
+    $expectedDate = $expectedDate->format('Y-m-d H:i:s');
+
+    $this->assertEquals($expectedDate, $newRecurContribution['create_date']);
+  }
+
+  public function testImportWithNoCreateDateWillDefaultToTodayDate() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test28';
+    unset($this->sampleRowData['payment_plan_create_date']);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $expectedDate = new DateTime();
+    $expectedDate = $expectedDate->format('Y-m-d');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d H:i:s', $newRecurContribution['create_date']);
+    $storedDate = $storedDate->format('Y-m-d');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportWillSetCorrectNextContributionDateValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test29';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['payment_plan_next_contribution_date']);
+    $expectedDate = $expectedDate->format('Y-m-d H:i:s');
+
+    $this->assertEquals($expectedDate, $newRecurContribution['next_sched_contribution_date']);
+  }
+
+  public function testImportWithNoNextContributionDateWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test30';
+    unset($this->sampleRowData['payment_plan_next_contribution_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(800);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  private function getRecurContributionsByContactId($contactId) {
+    $recurContributionIds = NULL;
+
+    $sqlQuery = "SELECT id FROM civicrm_contribution_recur WHERE contact_id = %1";
+    $recurContributions = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$contactId, 'Integer']]);
+    while ($recurContributions->fetch()) {
+      $recurContributionIds[] = $recurContributions->id;
+    }
+
+    return $recurContributionIds;
+  }
+
+  private function getRecurContributionsById($id) {
+    $recurContributionIds = NULL;
+
+    $sqlQuery = "SELECT * FROM civicrm_contribution_recur WHERE id = %1";
+    $recurContribution = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$id, 'Integer']]);
+    $recurContribution->fetch();
+
+    return $recurContribution->toArray();
+  }
+
+  private function getRecurContributionStatusId($statusName) {
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'contribution_recur_status' AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$statusName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getRecurContributionPaymentProcessorId($ppName) {
+    $sqlQuery = "SELECT id FROM civicrm_payment_processor WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$ppName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getRecurContributionFinancialTypeId($ftName) {
+    $sqlQuery = "SELECT id FROM civicrm_financial_type WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$ftName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getRecurContributionPaymentMethodId($pmName) {
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'payment_instrument' AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$pmName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+}

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -438,7 +438,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
   }
 
   private function getRecurContributionPaymentProcessorId($ppName) {
-    $sqlQuery = "SELECT id FROM civicrm_payment_processor WHERE name = %1";
+    $sqlQuery = "SELECT id FROM civicrm_payment_processor WHERE name = %1 and is_test = 0";
     $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$ppName, 'String']]);
     $result->fetch();
     return $result->id;

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,9 +2,16 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
-// phpcs:disable
+
+define('CIVICRM_TEST', 1);
+putenv('CIVICRM_UF=' . ($_ENV['CIVICRM_UF'] = 'UnitTests'));
+
 eval(cv('php:boot --level=settings', 'phpcode'));
-// phpcs:enable
+
+if (CIVICRM_UF === 'UnitTests') {
+  Civi\Test::headless()->apply();
+}
+
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();
 $loader->add('CRM_', __DIR__);

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot --level=settings', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+require_once 'BaseHeadlessTest.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
This adds a new API endpoint : `MembershipextrasImporter.create` which will be used within **nz.co.fuzion.csvimport** extension to import membership payment orders.

Also as part of this PR,  I created the first step in importing membership payment plan orders, which is creating recurring contributions. To achieve that, the following fields are added to the API mention above : 


- `Contact Id`: The contact that we are adding the order for. this assumes that the contact is already there and the id supplied is the contact Id in CiviCRM. Either this or the field above contact_id are required to do the import.
- `Contact External Id`: The contact that we are adding the order for. this assumes that the contact is already there but we match it using its external id. Either this or the field above contact_id are required to do the import.
- `Payment Plan External Id`:  represents the id of the payment plan (recurring contribution) from the system we are importing the data from, we will create new recurring contribution if no recur contribution exists with the same external id, otherwise nothing will happen (at least for now). It also worth mentioning that we store the external id after creating the recurring contribution in a custom group/field called  (Recurring Contribution External ID/External ID) that are defined in Membershipextras extension.
- `Payment Plan Payment Processor`: The recurring contribution payment processor, required field and matched by name (for now).
- `Payment Plan Total Amount`: The recurring contribution amount, for now, it takes the amount from the CSV file as is but later we need to change that to be the latest instalment amount.
- `Payment Plan Frequency`: Required and Can be either `month` or `year`, if `month` is selected then it will default the recurring contribution frequency unit to = `month`. the frequency interval to `1` and the instalments to `12`. If `year` is selected then the same values will be `year, `1` and `1` respectively. Having other than these two values will throw an error.
- `Payment Plan Next Contribution Date`: The recur contribution next scheduled contribution date, a required field.
- `Payment Plan Start Date`: The start date of the recurring contribution, will default to today date if not set.
- `Payment Plan Create Date`: The creation date of the recurring contribution will default to today date if not set.
- `Payment Plan Cycle Day`: The cycle day of the recurring contribution, if the frequency is `year` then it will not be set even if it is present in the CSV, if it is `month` then it will take the value provided in the CSV file and will throw an error if it is not present.
- `Payment Plan Auto Renew?`: Flag to specify if the recurring contribution is autorenewal or not, defaults to False if not set.
- `Payment Plan Financial Type`: The recurring contribution financial type, required field and matched by name (for now).
- `Payment Plan Status`: The recurring contribution Status, required field and matched by name (for now).
- `Payment Plan Payment Method`: The recurring contribution payment method, required field and matched by name (for now).

Some open points that still need to be discussed. figured out and/or done at some later point : 

- The amount of the recurring contribution should be set to last instalment (contribution) amount, I am not doing this yet here since I am not sure yet if we can guarantee that payment plan instalment in the CSV will be ordered by their receive date or not.
- I am currently defaulting the currency of the recurring contribution to `GBP` but that should not be the case, and while it does not make much sense to have such field since the different related contributions might have different currencies (in case the contact change his county for example), so we need to discuss if we need to supply this in the CSV file or if we just take if from the last instalment (contribution) currency.
- The payment method is not mentioned in the specs doc, but since it is a required field in CiviCRM I had to add it, but same as in the currency field, we need to discuss if to take it from latest instalment (contribution ) or not.
- If the payment processor being used is "Direct Debit", then we need to add validation to confirm that other direct debit fields exist in the CSV, I will do that when I create the direct debit mandate importer step.

Here are some screenshots from a sample import process and the resulting recur contribution.

![2020-12-31 15_54_59-Window](https://user-images.githubusercontent.com/6275540/103413062-ef1c6280-4b6f-11eb-8aac-f4349ad839b8.png)

![2020-12-31 15_55_27-Window](https://user-images.githubusercontent.com/6275540/103413067-f3488000-4b6f-11eb-8f80-ea01ca920267.png)

![2020-12-31 15_55_50-Window](https://user-images.githubusercontent.com/6275540/103413074-f6437080-4b6f-11eb-93b6-54ef395a8400.png)

![2020-12-31 15_56_30-Window](https://user-images.githubusercontent.com/6275540/103413112-183cf300-4b70-11eb-8f56-e21d645144ee.png)


![2020-12-31 15_57_02-Window](https://user-images.githubusercontent.com/6275540/103413114-1b37e380-4b70-11eb-9d91-818be1e2c59a.png)


and here is the CSV file that was used : 


[v1.zip](https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/files/5757407/v1.zip)

