### PR TITLE
MAE-433: Adding Memberships Importer

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -14,6 +14,9 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
   public function import() {
     $recurContributionImporter = new CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution($this->rowData, $this->contactId);
     $recurContributionId = $recurContributionImporter->import();
+
+    $membershipImporter = new CRM_Membershipextrasimporterapi_EntityImporter_Membership($this->rowData, $this->contactId, $recurContributionId);
+    $membershipId = $membershipImporter->import();
   }
 
   private function getContactId() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -1,0 +1,151 @@
+<?php
+
+class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
+
+  private $rowData;
+
+  private $recurContributionId;
+
+  private $contactId;
+
+  public function __construct($rowData, $contactId, $recurContributionId) {
+    $this->rowData = $rowData;
+    $this->contactId = $contactId;
+    $this->recurContributionId = $recurContributionId;
+  }
+
+  public function import() {
+    $membershipId = $this->getMembershipIdIfExist();
+    if ($membershipId) {
+      return $membershipId;
+    }
+
+    $sqlParams = $this->prepareSqlParams();
+    $sqlQuery = "INSERT INTO `civicrm_membership` (`contact_id` , `membership_type_id`, `join_date`, `start_date`, `end_date`, `status_id`,
+                 `is_pay_later`, `contribution_recur_id`, `is_override`, `status_override_end_date`) 
+            VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as membership_id');
+    $dao->fetch();
+    $membershipId = $dao->membership_id;
+
+    $sqlQuery = "INSERT INTO `civicrm_value_membership_ext_id` (`entity_id` , `external_id`) 
+           VALUES ({$membershipId}, %1)";
+    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
+
+    return $membershipId;
+  }
+
+  private function getMembershipIdIfExist() {
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_membership_ext_id WHERE external_id = %1";
+    $membershipId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
+    $membershipId->fetch();
+
+    if (!empty($membershipId->id)) {
+      return $membershipId->id;
+    }
+
+    return NULL;
+  }
+
+
+  private function prepareSqlParams() {
+    $membershipTypeId = $this->getMembershipTypeId();
+    $membershipStatusId = $this->getMembershipStatusId();
+    $statusOverrideEndDate = $this->getStatusOverrideEndDate();
+    $isOverriddenStatus = $this->isOverriddenStatus($statusOverrideEndDate);
+    $joinDate = $this->formatRowDate('membership_join_date', 'Join Date', TRUE);
+    $startDate = $this->formatRowDate('membership_start_date', 'Start Date', TRUE);
+    $endDate = $this->formatRowDate('membership_end_date', 'End Date', TRUE);
+
+    return [
+      1 => [$this->contactId, 'Integer'],
+      2 => [$membershipTypeId, 'Integer'],
+      3 => [$joinDate, 'Date'],
+      4 => [$startDate, 'Date'],
+      5 => [$endDate, 'Date'],
+      6 => [$membershipStatusId, 'Integer'],
+      7 => [1, 'Integer'],
+      8 => [$this->recurContributionId, 'Integer'],
+      9 => [$isOverriddenStatus, 'Integer'],
+      10 => [$statusOverrideEndDate, 'Date'],
+    ];
+  }
+
+  private function getMembershipTypeId() {
+    if (empty($this->rowData['membership_type'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException('Membership type is required field', 100);
+    }
+
+    $sqlQuery = "SELECT id FROM civicrm_membership_type WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_type'], 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException('Invalid membership type', 200);
+  }
+
+  private function getMembershipStatusId() {
+    if (empty($this->rowData['membership_status'])) {
+      $statusId = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate(
+        $this->rowData['membership_start_date'],
+        $this->rowData['membership_end_date'],
+        $this->rowData['membership_join_date'],
+        'now',
+        1
+      );
+
+      return $statusId['id'];
+    }
+
+    $sqlQuery = "SELECT id FROM civicrm_membership_status WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_status'], 'String']]);
+
+    if ($result->fetch()) {
+      return $result->id;
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException('Invalid membership status', 300);
+  }
+
+  private function getStatusOverrideEndDate() {
+    if (!empty($this->rowData['membership_status_override_end_date'])) {
+      return $this->formatRowDate('membership_status_override_end_date', 'Membership status override end date');
+    }
+
+    return NULL;
+  }
+
+  private function isOverriddenStatus($statusOverrideEndDate) {
+    if (!empty($statusOverrideEndDate)) {
+      return 2;
+    }
+
+    if (empty($this->rowData['membership_is_status_overridden'])) {
+      return 0;
+    }
+
+   return 1;
+  }
+
+  private function formatRowDate($dateColumnName, $columnLabel, $isRequired = FALSE) {
+    if ($isRequired && empty($this->rowData[$dateColumnName])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException("Membership '{$columnLabel}' is required field.", 400);
+    }
+
+    if (!empty($this->rowData[$dateColumnName])) {
+      $date = DateTime::createFromFormat('YmdHis', $this->rowData[$dateColumnName]);
+      $date = $date->format('Ymd');
+    }
+    else {
+      $date = new DateTime();
+      $date = $date->format('Ymd');
+    }
+
+    return $date;
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -65,6 +65,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
     $joinDate = $this->formatRowDate('membership_join_date', 'Join Date', TRUE);
     $startDate = $this->formatRowDate('membership_start_date', 'Start Date', TRUE);
     $endDate = $this->formatRowDate('membership_end_date', 'End Date', TRUE);
+    $isPayLater = 1;
 
     return [
       1 => [$this->contactId, 'Integer'],
@@ -73,7 +74,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
       4 => [$startDate, 'Date'],
       5 => [$endDate, 'Date'],
       6 => [$membershipStatusId, 'Integer'],
-      7 => [1, 'Integer'],
+      7 => [$isPayLater, 'Integer'],
       8 => [$this->recurContributionId, 'Integer'],
       9 => [$isOverriddenStatus, 'Integer'],
       10 => [$statusOverrideEndDate, 'Date'],
@@ -139,14 +140,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
   private function isOverriddenStatus($statusOverrideEndDate) {
     if (!empty($statusOverrideEndDate)) {
-      return 2;
+      return CRM_Member_StatusOverrideTypes::UNTIL_DATE;
     }
 
     if (empty($this->rowData['membership_is_status_overridden'])) {
-      return 0;
+      return CRM_Member_StatusOverrideTypes::NO;
     }
 
-    return 1;
+    return CRM_Member_StatusOverrideTypes::PERMANENT;
   }
 
   private function formatRowDate($dateColumnName, $columnLabel, $isRequired = FALSE) {

--- a/CRM/Membershipextrasimporterapi/Exception/InvalidMembershipFieldException.php
+++ b/CRM/Membershipextrasimporterapi/Exception/InvalidMembershipFieldException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException extends Exception {}

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -23,6 +23,7 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'type' => CRM_Utils_Type::T_STRING,
   ];
 
+  // Recur Contribution (Payment Plan)
   $params['payment_plan_external_id'] = [
     'title' => 'Payment Plan External Id',
     'type' => CRM_Utils_Type::T_STRING,
@@ -89,4 +90,44 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'api.required' => 1,
   ];
 
+  // Membership
+  $params['membership_external_id'] = [
+    'title' => 'Membership External Id',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['membership_type'] = [
+    'title' => 'Membership Type',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['membership_join_date'] = [
+    'title' => 'Membership Join Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['membership_start_date'] = [
+    'title' => 'Membership Start Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['membership_end_date'] = [
+    'title' => 'Membership End Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['membership_status'] = [
+    'title' => 'Membership Status',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['membership_is_status_overridden'] = [
+    'title' => 'Membership Status Overridden?',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $params['membership_status_override_end_date'] = [
+    'title' => 'Membership Status Override End Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
 }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -1,0 +1,305 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_EntityImporter_Membership as MembershipImporter;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+/**
+ *
+ * @group headless
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends BaseHeadlessTest {
+
+  private $sampleRowData = [
+    'membership_external_id' => 'test1',
+    'membership_type' => 'Student',
+    'membership_join_date' => '20180101000000',
+    'membership_start_date' => '20190101000000',
+    'membership_end_date' => '20191231000000',
+    'membership_status' => 'Current',
+    'membership_is_status_overridden' => 0,
+  ];
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  public function setUp() {
+    $this->contactId = ContactFabricator::fabricate()['id'];
+
+    $recurContributionParams = ['contact_id' => $this->contactId, 'amount' => 50, 'frequency_interval' => 1];
+    $this->recurContributionId = RecurContributionFabricator::fabricate($recurContributionParams)['id'];
+
+    MembershipTypeFabricator::fabricate(['name' => 'Student', 'minimum_fee' => 50]);
+  }
+
+  public function testImportNewMembership() {
+    $beforeImportIds = $this->getMembershipsByContactId($this->contactId);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $afterImportIds = $this->getMembershipsByContactId($this->contactId);
+
+    $importSucceed = FALSE;
+    if (empty($beforeImportIds) && $afterImportIds[0] == $newMembershipId) {
+      $importSucceed = TRUE;
+    }
+
+    $this->assertTrue($importSucceed);
+  }
+
+  public function testImportExistingMembershipWillNotCreateNewOne() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test2';
+
+    $firstImport = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $firstMembershipId = $firstImport->import();
+
+    $secondImport = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $secondMembershipId = $secondImport->import();
+
+    $this->assertEquals($firstMembershipId, $secondMembershipId);
+  }
+
+  public function testImportWillSetCorrectRecurContributionId() {
+    $this->sampleRowData['membership_external_id'] = 'test3';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $this->assertEquals($this->recurContributionId, $newMembership['contribution_recur_id']);
+  }
+
+  public function testImportWillCreateExternalIdCustomFieldRecord() {
+    $this->sampleRowData['membership_external_id'] = 'test4';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_membership_ext_id WHERE external_id = %1 AND entity_id = {$newMembershipId}";
+    $membershipId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->sampleRowData['membership_external_id'], 'String']]);
+    $membershipId->fetch();
+
+    $this->assertEquals(1, $membershipId->N);
+  }
+
+  public function testImportWillSetCorrectJoinDateValue() {
+    $this->sampleRowData['membership_external_id'] = 'test5';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['membership_join_date']);
+    $expectedDate = $expectedDate->format('Y-m-d');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d', $newMembership['join_date']);
+    $storedDate = $storedDate->format('Y-m-d');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportWithNoJoinDateThrowException() {
+    $this->sampleRowData['membership_external_id'] = 'test6';
+    unset($this->sampleRowData['membership_join_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(400);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
+  public function testImportWillSetCorrectStartDateValue() {
+    $this->sampleRowData['membership_external_id'] = 'test7';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['membership_start_date']);
+    $expectedDate = $expectedDate->format('Y-m-d');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d', $newMembership['start_date']);
+    $storedDate = $storedDate->format('Y-m-d');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportWithNoStartDateThrowException() {
+    $this->sampleRowData['membership_external_id'] = 'test8';
+    unset($this->sampleRowData['membership_start_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(400);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
+  public function testImportWillSetCorrectEndDateValue() {
+    $this->sampleRowData['membership_external_id'] = 'test9';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['membership_end_date']);
+    $expectedDate = $expectedDate->format('Y-m-d');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d', $newMembership['end_date']);
+    $storedDate = $storedDate->format('Y-m-d');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportWithNoEndDateThrowException() {
+    $this->sampleRowData['membership_external_id'] = 'test10';
+    unset($this->sampleRowData['membership_end_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(400);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
+  public function testImportWillSetCorrectMembershipTypeValue() {
+    $this->sampleRowData['membership_external_id'] = 'test11';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedTypeId = $this->getMembershipTypeId($this->sampleRowData['membership_type']);
+
+    $this->assertEquals($expectedTypeId, $newMembership['membership_type_id']);
+  }
+
+  public function testImportWithNoMembershipTypeThrowException() {
+    $this->sampleRowData['membership_external_id'] = 'test12';
+    unset($this->sampleRowData['membership_type']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(100);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
+  public function testImportWillSetCorrectMembershipStatusValue() {
+    $this->sampleRowData['membership_external_id'] = 'test13';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedStatusId = $this->getMembershipStatusId($this->sampleRowData['membership_status']);
+
+    $this->assertEquals($expectedStatusId, $newMembership['status_id']);
+  }
+
+  public function testImportWithNoMembershipStatusWillAutomaticallyCalculateIt() {
+    $this->sampleRowData['membership_external_id'] = 'test14';
+    unset($this->sampleRowData['membership_status']);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $expectedStatusId = $this->getMembershipStatusId('Expired');
+
+    $this->assertEquals($expectedStatusId, $newMembership['status_id']);
+  }
+
+  public function testImportWillSetCorrectIsStatusOverrideValue() {
+    $this->sampleRowData['membership_external_id'] = 'test15';
+    $this->sampleRowData['membership_is_status_overridden'] = 1;
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $this->assertEquals(1, $newMembership['is_override']);
+  }
+
+  public function testImportWillDefaultIsStatusOverrideToNo() {
+    $this->sampleRowData['membership_external_id'] = 'test16';
+    unset($this->sampleRowData['membership_is_status_overridden']);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $this->assertEquals(0, $newMembership['is_override']);
+  }
+
+  public function testImportWithOverrideEndDateSetWillDefaultIsStatusOverrideToCorrectValue() {
+    $this->sampleRowData['membership_external_id'] = 'test17';
+    $this->sampleRowData['membership_status_override_end_date'] = '20300101000000';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $this->assertEquals(2, $newMembership['is_override']);
+  }
+
+  public function testImportWithOverrideEndDateWillSetItToCorrectValue() {
+    $this->sampleRowData['membership_external_id'] = 'test18';
+    $this->sampleRowData['membership_status_override_end_date'] = '20300101000000';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newMembershipId = $membershipImporter->import();
+
+    $newMembership = $this->getMembershipById($newMembershipId);
+
+    $this->assertEquals('2030-01-01', $newMembership['status_override_end_date']);
+  }
+
+  private function getMembershipsByContactId($contactId) {
+    $membershipIds = NULL;
+
+    $sqlQuery = "SELECT id FROM civicrm_membership WHERE contact_id = %1";
+    $memberships = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$contactId, 'Integer']]);
+    while ($memberships->fetch()) {
+      $membershipIds[] = $memberships->id;
+    }
+
+    return $membershipIds;
+  }
+
+  private function getMembershipById($id) {
+    $sqlQuery = "SELECT * FROM civicrm_membership WHERE id = %1";
+    $membership = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$id, 'Integer']]);
+    $membership->fetch();
+
+    return $membership->toArray();
+  }
+
+  private function getMembershipTypeId($typeName) {
+    $sqlQuery = "SELECT id FROM civicrm_membership_type WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$typeName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getMembershipStatusId($statusName) {
+    $sqlQuery = "SELECT id FROM civicrm_membership_status WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$statusName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+}

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -223,14 +223,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
   public function testImportWillSetCorrectIsStatusOverrideValue() {
     $this->sampleRowData['membership_external_id'] = 'test15';
-    $this->sampleRowData['membership_is_status_overridden'] = 1;
+    $this->sampleRowData['membership_is_status_overridden'] = CRM_Member_StatusOverrideTypes::PERMANENT;
 
     $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $newMembershipId = $membershipImporter->import();
 
     $newMembership = $this->getMembershipById($newMembershipId);
 
-    $this->assertEquals(1, $newMembership['is_override']);
+    $this->assertEquals(CRM_Member_StatusOverrideTypes::PERMANENT, $newMembership['is_override']);
   }
 
   public function testImportWillDefaultIsStatusOverrideToNo() {
@@ -242,7 +242,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
     $newMembership = $this->getMembershipById($newMembershipId);
 
-    $this->assertEquals(0, $newMembership['is_override']);
+    $this->assertEquals(CRM_Member_StatusOverrideTypes::NO, $newMembership['is_override']);
   }
 
   public function testImportWithOverrideEndDateSetWillDefaultIsStatusOverrideToCorrectValue() {
@@ -254,7 +254,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
     $newMembership = $this->getMembershipById($newMembershipId);
 
-    $this->assertEquals(2, $newMembership['is_override']);
+    $this->assertEquals(CRM_Member_StatusOverrideTypes::UNTIL_DATE, $newMembership['is_override']);
   }
 
   public function testImportWithOverrideEndDateWillSetItToCorrectValue() {

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -4,6 +4,7 @@ use CRM_Membershipextrasimporterapi_EntityImporter_Membership as MembershipImpor
 use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
 use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
 use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+
 /**
  *
  * @group headless


### PR DESCRIPTION
This adds  new fields to the API endpoint: `MembershipextrasImporter.create`  that allows users to import memberships and attach them to the Payment Plans created in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/2

The new fields are : 

- `Membership External Id`:  The membership identifier from the system we are importing memberships from, for the time being, we assume that if it exists then the row is a membership row and the importer will try to import the membership, once we write the line item importer then we will change that to check the entity_table column instead.
- `Membership Type`: The membership type, required and matched by Name.
- `Membership Join Date`, `Membership Start Date`, `Membership End Date`: The dates of the membership, all required.
- `Membership Status`: The membership status, matched by name. If not set then it will be automatically calculated using CiviCRM status rules calculation logic.
- `Membership Status Overridden?` : should be `1` if we want to override the membership status.
- `Membership Status Override End Date`: If this is not empty and is set to a certain date, then the `Membership Status Overridden?` value will default to `2` and the membership status w2ill be overridden until the date specified in this field.

Here are some screenshots from a sample import process and the resulting membership:


![2021-01-05 19_26_10-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/103678346-53c62b80-4f7b-11eb-8afd-faaefd458287.png)

![2021-01-05 19_26_35-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/103678355-56c11c00-4f7b-11eb-8ed2-3798ed4185d9.png)

![2021-01-05 19_26_58-ffgdgfd fdgfdg _ compuvag5one](https://user-images.githubusercontent.com/6275540/103678375-59237600-4f7b-11eb-8d45-64e5d8bd73d5.png)

![2021-01-05 19_27_16-ffgdgfd fdgfdg _ compuvag5one](https://user-images.githubusercontent.com/6275540/103678380-5b85d000-4f7b-11eb-8384-1105384d7286.png)




and here is the CSV file that was used : 


[V2.zip](https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/files/5771622/V2.zip)


