### PR TITLE
MAE-434: Adding contribution importer

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -17,6 +17,9 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
     $membershipImporter = new CRM_Membershipextrasimporterapi_EntityImporter_Membership($this->rowData, $this->contactId, $recurContributionId);
     $membershipId = $membershipImporter->import();
+
+    $contributionImporter = new CRM_Membershipextrasimporterapi_EntityImporter_Contribution($this->rowData, $this->contactId, $recurContributionId);
+    $contributionId = $contributionImporter->import();
   }
 
   private function getContactId() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -1,0 +1,243 @@
+<?php
+
+class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
+
+  private $rowData;
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  private $cachedValues;
+
+  public function __construct($rowData, $contactId, $recurContributionId) {
+    $this->rowData = $rowData;
+    $this->contactId = $contactId;
+    $this->recurContributionId = $recurContributionId;
+  }
+
+  public function import() {
+    if (empty($this->rowData['contribution_external_id'])) {
+      return NULL;
+    }
+
+    $contributionId = $this->getContributionIdIfExist();
+    if ($contributionId) {
+      return $contributionId;
+    }
+
+    $sqlParams = $this->prepareSqlParams();
+    $sqlQuery = "INSERT INTO `civicrm_contribution` (`contact_id` , `financial_type_id` , `payment_instrument_id` , 
+                 `receive_date` , `total_amount` , `currency`, `contribution_recur_id` , `is_pay_later`,
+                  `contribution_status_id`) 
+                 VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as contribution_id');
+    $dao->fetch();
+    $contributionId = $dao->contribution_id;
+
+    $sqlQuery = "INSERT INTO `civicrm_value_contribution_ext_id` (`entity_id` , `external_id`) 
+           VALUES ({$contributionId}, %1)";
+    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contribution_external_id'], 'String']]);
+
+    $mappedContributionParams = $this->mapContributionSQLParamsToNames($sqlParams);
+    $financialTransactionId = $this->createFinancialTransactionRecord($mappedContributionParams);
+    $this->createEntityFinancialTransactionRecord($contributionId, $financialTransactionId, $mappedContributionParams);
+
+    return $contributionId;
+  }
+
+  private function getContributionIdIfExist() {
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_contribution_ext_id WHERE external_id = %1";
+    $contributionId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contribution_external_id'], 'String']]);
+    $contributionId->fetch();
+
+    if (!empty($contributionId->id)) {
+      return $contributionId->id;
+    }
+
+    return NULL;
+  }
+
+  private function prepareSqlParams() {
+    $financialTypeId = $this->getFinancialTypeId();
+    $paymentMethodId = $this->getPaymentMethodId();
+    $receiveDate = $this->formatRowDate('contribution_received_date');
+    $totalAmount = $this->getTotalAmount();
+    $currency = $this->getCurrency();
+    $isPayLater = $this->calculateIsPayLaterFlag();
+    $contributionStatusId  = $this->getContributionStatusId();
+
+    return [
+      1 => [$this->contactId, 'Integer'],
+      2 => [$financialTypeId, 'Integer'],
+      3 => [$paymentMethodId, 'Integer'],
+      4 => [$receiveDate, 'Date'],
+      5 => [$totalAmount, 'Money'],
+      6 => [$currency, 'String'],
+      7 => [$this->recurContributionId, 'Integer'],
+      8 => [$isPayLater, 'Integer'],
+      9 => [$contributionStatusId, 'Integer'],
+    ];
+  }
+
+  private function mapContributionSQLParamsToNames($contributionSqlParams) {
+    return [
+      'contact_id' => $contributionSqlParams[1][0],
+      'financial_type_id' => $contributionSqlParams[2][0],
+      'payment_method_id' => $contributionSqlParams[3][0],
+      'receive_date' => $contributionSqlParams[4][0],
+      'total_amount' => $contributionSqlParams[5][0],
+      'currency' => $contributionSqlParams[6][0],
+      'recur_contribution_id' => $contributionSqlParams[7][0],
+      'is_pay_later' => $contributionSqlParams[8][0],
+      'contribution_status_id' => $contributionSqlParams[9][0],
+    ];
+  }
+
+  private function getFinancialTypeId() {
+    if (!isset($this->cachedValues['financial_types'])) {
+      $sqlQuery = "SELECT id, name FROM civicrm_financial_type";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['financial_types'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['financial_types'][$this->rowData['contribution_financial_type']])) {
+      return $this->cachedValues['financial_types'][$this->rowData['contribution_financial_type']];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException('Invalid contribution "Financial Type"', 100);
+  }
+
+  private function getPaymentMethodId() {
+    if (!isset($this->cachedValues['payment_methods'])) {
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'payment_instrument'";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['payment_methods'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['payment_methods'][$this->rowData['contribution_payment_method']])) {
+      return $this->cachedValues['payment_methods'][$this->rowData['contribution_payment_method']];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException('Invalid contribution "Payment Method"', 200);
+  }
+
+  private function formatRowDate($dateColumnName) {
+    if (!empty($this->rowData[$dateColumnName])) {
+      $date = DateTime::createFromFormat('YmdHis', $this->rowData[$dateColumnName]);
+      $date = $date->format('YmdHis');
+    }
+    else {
+      $date = new DateTime();
+      $date = $date->format('YmdHis');
+    }
+
+    return $date;
+  }
+
+  private function getTotalAmount() {
+    //todo : figure out a way to calculate amount, defaulting it to zero for now
+    return 0;
+  }
+
+  private function getCurrency() {
+    // todo : not in mapping document, need to discuss with others how to get it.
+    return 'GBP';
+  }
+
+  private function calculateIsPayLaterFlag() {
+    $statusName = 'Completed';
+    if (!empty($this->rowData['contribution_status'])) {
+      $statusName = $this->rowData['contribution_status'];
+    }
+
+    if (in_array($statusName, ['Pending', 'In Progress'])) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private function getContributionStatusId() {
+    $statusName = 'Completed';
+    if (!empty($this->rowData['contribution_status'])) {
+      $statusName = $this->rowData['contribution_status'];
+    }
+
+    if (!isset($this->cachedValues['contribution_statuses'])) {
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'contribution_status'";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['contribution_statuses'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['contribution_statuses'][$statusName])) {
+      return $this->cachedValues['contribution_statuses'][$statusName];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException('Invalid contribution "Status"', 300);
+  }
+
+  private function createFinancialTransactionRecord($mappedContributionParams) {
+    $sqlParams = [
+      1 => [$this->getToFinancialAccountId(), 'Integer'],
+      2 => [$mappedContributionParams['total_amount'], 'Money'],
+      3 => [$mappedContributionParams['currency'], 'String'],
+      4 => [$mappedContributionParams['contribution_status_id'], 'Integer'],
+      5 => [$mappedContributionParams['payment_method_id'], 'Integer'],
+    ];
+    $sqlQuery = "INSERT INTO `civicrm_financial_trxn` (`to_financial_account_id`, `total_amount` , `currency`, `status_id` , `payment_instrument_id`) 
+            VALUES (%1 , %2, %3, %4, %5)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as id');
+    $dao->fetch();
+    return $dao->id;
+  }
+
+  /**
+   * Gets the "To Financial account id" for the contribution.
+   *
+   * Given that the payment processor is required field
+   * for the import, we are using it to get to
+   * get the financial account value.
+   *
+   * @return id
+   */
+  private function getToFinancialAccountId() {
+    $paymentProcessorId = $this->getPaymentProcessorIdFromRecurContribution();
+    $sqlQuery = "SELECT financial_account_id FROM civicrm_entity_financial_account 
+                   WHERE entity_table = 'civicrm_payment_processor' AND entity_id = {$paymentProcessorId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+    return $result->financial_account_id;
+  }
+
+  private function getPaymentProcessorIdFromRecurContribution() {
+    $sqlQuery = "SELECT payment_processor_id from civicrm_contribution_recur WHERE id = {$this->recurContributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+    return $result->payment_processor_id;
+  }
+
+  private function createEntityFinancialTransactionRecord($contributionId, $financialTransactionId, $mappedContributionParams) {
+    $sqlParams = [
+      1 => [$mappedContributionParams['total_amount'], 'String'],
+    ];
+    $sqlQuery = "INSERT INTO `civicrm_entity_financial_trxn` (`entity_table`, `entity_id` , `financial_trxn_id`, `amount`) 
+                VALUES ('civicrm_contribution', {$contributionId}, {$financialTransactionId}, %1)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -190,15 +190,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   }
 
   private function getPaymentMethodId() {
-    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
-                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
-                  WHERE cog.name = 'payment_instrument'  AND cov.name = %1";
-    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_payment_method'], 'String']]);
-
-    if ($result->fetch()) {
-      return $result->id;
-    }
-
     if (!isset($this->cachedValues['payment_methods'])) {
       $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
                   INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 

--- a/CRM/Membershipextrasimporterapi/Exception/InvalidContributionFieldException.php
+++ b/CRM/Membershipextrasimporterapi/Exception/InvalidContributionFieldException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException extends Exception {}

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -130,4 +130,34 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'title' => 'Membership Status Override End Date',
     'type' => CRM_Utils_Type::T_DATE,
   ];
+
+  // Contribution
+  $params['contribution_external_id'] = [
+    'title' => 'Contribution External Id',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['contribution_financial_type'] = [
+    'title' => 'Contribution Financial Type',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['contribution_payment_method'] = [
+    'title' => 'Contribution Payment Method',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['contribution_received_date'] = [
+    'title' => 'Contribution Received Date',
+    'type' => CRM_Utils_Type::T_DATE,
+    'api.required' => 1,
+  ];
+
+  $params['contribution_status'] = [
+    'title' => 'Contribution Status',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
@@ -1,0 +1,300 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_EntityImporter_Contribution as ContributionImporter;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
+
+/**
+ *
+ * @group headless
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends BaseHeadlessTest {
+
+  private $sampleRowData = [
+    'contribution_external_id' => 'test1',
+    'contribution_financial_type' => 'Member Dues',
+    'contribution_payment_method' => 'EFT',
+    'contribution_received_date' => '20190101013040',
+    'contribution_status' => 'Pending',
+  ];
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  private $testPaymentProcessorId = 1;
+
+  public function setUp() {
+    $this->contactId = ContactFabricator::fabricate()['id'];
+
+    $recurContributionParams = ['contact_id' => $this->contactId, 'amount' => 50, 'frequency_interval' => 1, 'payment_processor_id' => $this->testPaymentProcessorId];
+    $this->recurContributionId = RecurContributionFabricator::fabricate($recurContributionParams)['id'];
+  }
+
+  public function testImportNewContribution() {
+    $beforeImportIds = $this->getContributionsByContactId($this->contactId);
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $afterImportIds = $this->getContributionsByContactId($this->contactId);
+
+    $importSucceed = FALSE;
+    if (empty($beforeImportIds) && $afterImportIds[0] == $newContributionId) {
+      $importSucceed = TRUE;
+    }
+
+    $this->assertTrue($importSucceed);
+  }
+
+  public function testImportExistingContributionWillNotCreateNewOne() {
+    $this->sampleRowData['contribution_external_id'] = 'test2';
+
+    $firstImport = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $firstContributionId = $firstImport->import();
+
+    $secondImport = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $secondContributionId = $secondImport->import();
+
+    $this->assertEquals($firstContributionId, $secondContributionId);
+  }
+
+  public function testImportWillSetCorrectRecurContributionId() {
+    $this->sampleRowData['membership_external_id'] = 'test3';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $this->assertEquals($this->recurContributionId, $newContribution['contribution_recur_id']);
+  }
+
+  public function testImportWillCreateExternalIdCustomFieldRecord() {
+    $this->sampleRowData['contribution_external_id'] = 'test4';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $sqlQuery = "SELECT entity_id as id FROM civicrm_value_contribution_ext_id WHERE external_id = %1 AND entity_id = {$newContributionId}";
+    $contributionId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->sampleRowData['contribution_external_id'], 'String']]);
+    $contributionId->fetch();
+
+    $this->assertEquals(1, $contributionId->N);
+  }
+
+  public function testImportWillSetCorrectFinancialTypeValue() {
+    $this->sampleRowData['contribution_external_id'] = 'test5';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $expectedFTId = $this->getContributionFinancialTypeId($this->sampleRowData['contribution_financial_type']);
+
+    $this->assertEquals($expectedFTId, $newContribution['financial_type_id']);
+  }
+
+  public function testImportWithInvalidFinancialTypeWillThrowAnException() {
+    $this->sampleRowData['contribution_external_id'] = 'test6';
+    $this->sampleRowData['contribution_financial_type'] = 'Invalid FT';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException::class);
+    $this->expectExceptionCode(100);
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $contributionImporter->import();
+  }
+
+  public function testImportWillSetCorrectPaymentMethodValue() {
+    $this->sampleRowData['contribution_external_id'] = 'test7';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $expectedPPId = $this->getContributionPaymentMethodId($this->sampleRowData['contribution_payment_method']);
+
+    $this->assertEquals($expectedPPId, $newContribution['payment_instrument_id']);
+  }
+
+  public function testImportWithInvalidPaymentMethodWillThrowAnException() {
+    $this->sampleRowData['contribution_external_id'] = 'test8';
+    $this->sampleRowData['contribution_payment_method'] = 'Invalid PM';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException::class);
+    $this->expectExceptionCode(200);
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $contributionImporter->import();
+  }
+
+  public function testImportWillSetCorrectReceiveDateValue() {
+    $this->sampleRowData['contribution_external_id'] = 'test9';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['contribution_received_date']);
+    $expectedDate = $expectedDate->format('Y-m-d H:i:s');
+
+    $storedDate = DateTime::createFromFormat('Y-m-d H:i:s', $newContribution['receive_date']);
+    $storedDate = $storedDate->format('Y-m-d H:i:s');
+
+    $this->assertEquals($expectedDate, $storedDate);
+  }
+
+  public function testImportPendingContributionWillSetIsPayLaterFlagToTrue() {
+    $this->sampleRowData['contribution_external_id'] = 'test10';
+    $this->sampleRowData['contribution_status'] = 'Pending';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $this->assertEquals(1, $newContribution['is_pay_later']);
+  }
+
+  public function testImportInProgressContributionWillSetIsPayLaterFlagToTrue() {
+    $this->sampleRowData['contribution_external_id'] = 'test11';
+    $this->sampleRowData['contribution_status'] = 'In Progress';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $this->assertEquals(1, $newContribution['is_pay_later']);
+  }
+
+  public function testImportCompletedContributionWillSetIsPayLaterFlagToFalse() {
+    $this->sampleRowData['contribution_external_id'] = 'test12';
+    $this->sampleRowData['contribution_status'] = 'Completed';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $this->assertEquals(0, $newContribution['is_pay_later']);
+  }
+
+  public function testImportWillSetCorrectStatusValue() {
+    $this->sampleRowData['contribution_external_id'] = 'test13';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $expectedStatusId = $this->getContributionStatusId($this->sampleRowData['contribution_status']);
+
+    $this->assertEquals($expectedStatusId, $newContribution['contribution_status_id']);
+  }
+
+  public function testImportWithoutStatusWillDefaultItToCompleted() {
+    $this->sampleRowData['contribution_external_id'] = 'test14';
+    unset($this->sampleRowData['contribution_status']);
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $expectedStatusId = $this->getContributionStatusId('Completed');
+
+    $this->assertEquals($expectedStatusId, $newContribution['contribution_status_id']);
+  }
+
+  public function testImportWithInvalidStatusWillThrowAnException() {
+    $this->sampleRowData['contribution_external_id'] = 'test15';
+    $this->sampleRowData['contribution_status'] = 'Invalid ST';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException::class);
+    $this->expectExceptionCode(300);
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $contributionImporter->import();
+  }
+
+  public function testImportWillCreateCorrectFinancialTransactionRecords() {
+    $this->sampleRowData['membership_external_id'] = 'test16';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+    $newContribution = $this->getContributionById($newContributionId);
+
+    $sqlQuery = "SELECT ceft.amount as ef_amount, cft.total_amount as f_amount, cft.currency, cft.status_id, cft.payment_instrument_id, cft.to_financial_account_id  
+                 FROM civicrm_entity_financial_trxn ceft
+                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id 
+                 WHERE ceft.entity_table = 'civicrm_contribution' AND ceft.entity_id = {$newContributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+
+    $this->assertEquals($newContribution['total_amount'], $result->ef_amount);
+    $this->assertEquals($newContribution['total_amount'], $result->f_amount);
+    $this->assertEquals($newContribution['currency'], $result->currency);
+    $this->assertEquals($newContribution['contribution_status_id'], $result->status_id);
+    $this->assertEquals($newContribution['payment_instrument_id'], $result->payment_instrument_id);
+    $this->assertEquals($this->getPaymentProcessorFinancialAccountId($this->testPaymentProcessorId), $result->to_financial_account_id);
+  }
+
+  private function getContributionsByContactId($contactId) {
+    $contributionIds = NULL;
+
+    $sqlQuery = "SELECT id FROM civicrm_contribution WHERE contact_id = %1";
+    $contributions = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$contactId, 'Integer']]);
+    while ($contributions->fetch()) {
+      $contributionIds[] = $contributions->id;
+    }
+
+    return $contributionIds;
+  }
+
+  private function getContributionById($id) {
+    $sqlQuery = "SELECT * FROM civicrm_contribution WHERE id = %1";
+    $contribution = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$id, 'Integer']]);
+    $contribution->fetch();
+
+    return $contribution->toArray();
+  }
+
+  private function getContributionFinancialTypeId($ftName) {
+    $sqlQuery = "SELECT id FROM civicrm_financial_type WHERE name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$ftName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getContributionPaymentMethodId($pmName) {
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'payment_instrument' AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$pmName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getContributionStatusId($statusName) {
+    $sqlQuery = "SELECT cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'contribution_status' AND cov.name = %1";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$statusName, 'String']]);
+    $result->fetch();
+    return $result->id;
+  }
+
+  private function getPaymentProcessorFinancialAccountId($paymentProcessorId) {
+    $sqlQuery = "SELECT financial_account_id FROM civicrm_entity_financial_account 
+                   WHERE entity_table = 'civicrm_payment_processor' AND entity_id = {$paymentProcessorId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+    return $result->financial_account_id;
+  }
+
+}


### PR DESCRIPTION
This adds new fields to the API endpoint: `MembershipextrasImporter.create`  that allows users to import contributions and attach them to the Payment Plans created in the previous PR.
The new fields are : 

- `Contribution External Id`:  The contribution identifier from the system we are importing things from
- `Contribution Financial Type`:  required and matched by Name.
- `Contribution Payment Method`, required and matched by Name.
- `Contribution Received Date`: required field.
- `Contribution Status`: If not set, then I default it to "Completed".


Aside from the above fields, I  set also the following ones automatically : 

- `contribution_recur_id` : Set to the recurring contribution id we created in the RecurContributionImporter
- `is_pay_later`: Same as in CiviCRM core, I default it to True if the contribution status is Pending or In Progress, otherwise I set to False.


And I also create the following records automatically, that are needed by CiviCRM : 

- `civicrm_financial_trxn`: The financial transaction record, every CiviCRM contribution should have such record, an as In core I set the "To Financial Account"
value to match the Payment processor financial account (given that we require the payment processor in the CSV we want to import)
- `civicrm_entity_financial_trxn`: And same as in CiviCRM core, I create this record to connect between the imported contribution and the financial transaction record created in the step above.


Here are some screenshots from a sample import process and the resulting contribution

![2021-01-12 14_30_06-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/104315108-5d4b1880-54d2-11eb-8072-5390b901b174.png)

![2021-01-12 14_31_44-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/104315126-6340f980-54d2-11eb-9620-439ae937a53b.png)


![2021-01-12 14_31_25-ddffds dfssfd _ compuvag5one](https://user-images.githubusercontent.com/6275540/104315138-66d48080-54d2-11eb-903e-e9ae10334981.png)

![2021-01-12 14_32_00-ddffds dfssfd _ compuvag5one](https://user-images.githubusercontent.com/6275540/104315148-6a680780-54d2-11eb-9f12-2c45ceb468ff.png)



and here is the CSV file that was used : 


[V3.zip](https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/files/5802067/V3.zip)



Also, there are still two things that need to be figured out at some point later which are : 

1- For now I default the contribution amount to 0, but if possible I need to calculate it from the line items, if not possible then we need to discuss the possibility of supplying it in the CSV file. Same applies to the tax amount.

2- I also and for now and same as in the recurring contribution, default the currency to GBP, but we need to decide if we want to supply it in the CSV file separately from the recurring contribution currency or just use the same one as the recurring contribution 

