### PR TITLE
MAE-431: Add Direct debit mandate importer

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -5,6 +5,7 @@ use CRM_Membershipextrasimporterapi_EntityImporter_Membership as MembershipImpor
 use CRM_Membershipextrasimporterapi_EntityImporter_Contribution as ContributionImporter;
 use CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment as MembershipPaymentCreator;
 use CRM_Membershipextrasimporterapi_EntityImporter_LineItem as LineItemImporter;
+use CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate as DirectDebitMandateImporter;
 
 class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
@@ -32,6 +33,9 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
     $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId);
     $lineItemImporter->import();
+
+    $mandateImporter = new DirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);
+    $mandateImporter->import();
   }
 
   private function getContactId() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandate.php
@@ -1,0 +1,243 @@
+<?php
+
+class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
+
+  private $rowData;
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  private $contributionId;
+
+  private $cachedValues;
+
+  public function __construct($rowData, $contactId, $recurContributionId, $contributionId) {
+    $this->rowData = $rowData;
+    $this->contactId = $contactId;
+    $this->recurContributionId = $recurContributionId;
+    $this->contributionId = $contributionId;
+  }
+
+  public function import() {
+    if (!$this->isDirectDebitPaymentProcessor()) {
+      return NULL;
+    }
+
+    $this->validateMandateReference();
+    $mandateId = $this->getMandateIdIfExist();
+
+    if (empty($mandateId)) {
+      $sqlParams = $this->prepareSqlParams();
+      $sql = "INSERT INTO civicrm_value_dd_mandate 
+            (entity_id, bank_name, account_holder_name, ac_number, sort_code, dd_code, dd_ref, start_date, originator_number) 
+            VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
+      CRM_Core_DAO::executeQuery($sql, $sqlParams);
+
+      $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as mandate_id');
+      $dao->fetch();
+      $mandateId = $dao->mandate_id;
+    }
+
+    if ($this->isRecurContributionAttachedToAnyMandate()) {
+      $sql = "UPDATE `dd_contribution_recurr_mandate_ref` SET `mandate_id` = {$mandateId} WHERE `recurr_id` = {$this->recurContributionId}";
+      CRM_Core_DAO::executeQuery($sql);
+    }
+    else {
+      $sql = "INSERT INTO `dd_contribution_recurr_mandate_ref` (`recurr_id` , `mandate_id`) 
+           VALUES ({$this->recurContributionId} , {$mandateId})";
+      CRM_Core_DAO::executeQuery($sql);
+    }
+
+    if (!$this->isMandateContributionRefExist($mandateId)) {
+      $sql = "INSERT INTO `civicrm_value_dd_information` (`mandate_id` , `entity_id`) 
+           VALUES ({$mandateId} , {$this->contributionId})";
+      CRM_Core_DAO::executeQuery($sql);
+    }
+
+    return $mandateId;
+  }
+
+  private function isDirectDebitPaymentProcessor() {
+    if ($this->rowData['payment_plan_payment_processor'] == 'Direct Debit') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function validateMandateReference() {
+    if (empty($this->rowData['direct_debit_mandate_reference'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate reference is required for Direct Debit payment plans', 100);
+    }
+  }
+
+  private function getMandateIdIfExist() {
+    $sql = "SELECT id FROM civicrm_value_dd_mandate WHERE dd_ref = %1";
+    $dao = CRM_Core_DAO::executeQuery($sql, [
+      1 => [$this->rowData['direct_debit_mandate_reference'], 'String'],
+    ]);
+
+    $dao->fetch();
+    if (!empty($dao->id)) {
+      return $dao->id;
+    }
+
+    return NULL;
+  }
+
+  private function isRecurContributionAttachedToAnyMandate() {
+    $sql = "SELECT mandate_id FROM dd_contribution_recurr_mandate_ref  
+            WHERE recurr_id = {$this->recurContributionId}";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+
+    $dao->fetch();
+    if (!empty($dao->mandate_id)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function isMandateContributionRefExist($mandateId) {
+    $sql = "SELECT mandate_id FROM civicrm_value_dd_information  
+            WHERE mandate_id = %1 AND entity_id = %2";
+    $dao = CRM_Core_DAO::executeQuery($sql, [
+      1 => [$mandateId, 'Integer'],
+      2 => [$this->contributionId, 'Integer'],
+    ]);
+
+    $dao->fetch();
+    if (!empty($dao->mandate_id)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function prepareSqlParams() {
+    $bankName = $this->getBankName();
+    $accountHolderName = $this->getAccountHolderName();
+    $accountNumber = $this->getAccountNumber();
+    $sortCode = $this->getSortCode();
+    $ddCode = $this->getDDCode();
+    $ddStartDate = $this->formatRowDate('direct_debit_mandate_start_date', 'Start Date', TRUE);
+    $originatorNumber = $this->getOriginatorNumber();
+
+    return [
+      1 => [$this->contactId, 'Integer'],
+      2 => [$bankName, 'String'],
+      3 => [$accountHolderName, 'String'],
+      4 => [$accountNumber, 'String'],
+      5 => [$sortCode, 'String'],
+      6 => [$ddCode, 'String'],
+      7 => [$this->rowData['direct_debit_mandate_reference'], 'String'],
+      8 => [$ddStartDate, 'Date'],
+      9 => [$originatorNumber, 'String'],
+    ];
+  }
+
+  private function getBankName() {
+    if (empty($this->rowData['direct_debit_mandate_bank_name'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate bank name is required for Direct Debit payment plans', 200);
+    }
+
+    return $this->rowData['direct_debit_mandate_bank_name'];
+  }
+
+  private function getAccountHolderName() {
+    if (empty($this->rowData['direct_debit_mandate_account_holder'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate account holder is required for Direct Debit payment plans', 300);
+    }
+
+    return $this->rowData['direct_debit_mandate_account_holder'];
+  }
+
+  private function getAccountNumber() {
+    if (empty($this->rowData['direct_debit_mandate_account_number'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate account number is required for Direct Debit payment plans', 400);
+    }
+
+    $accountNumber = $this->rowData['direct_debit_mandate_account_number'];
+
+    if (strlen($accountNumber) !== 8) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate account number should have 8 characters', 500);
+    }
+
+    return $accountNumber;
+  }
+
+  private function getSortCode() {
+    if (empty($this->rowData['direct_debit_mandate_sort_code'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate sort code is required for Direct Debit payment plans', 600);
+    }
+
+    $sortCode = $this->rowData['direct_debit_mandate_sort_code'];
+
+    if (strlen($sortCode) !== 6) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate sort code should have 6 characters', 700);
+    }
+
+    return $this->rowData['direct_debit_mandate_sort_code'];
+  }
+
+  private function getDDCode() {
+    if (empty($this->rowData['direct_debit_mandate_code'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate code is required for Direct Debit payment plans', 800);
+    }
+
+    $codesMapping = [
+      '0N' => 1,
+      '01' => 2,
+      '17' => 3,
+      '0C' => 4,
+    ];
+
+    $ddCode = $this->rowData['direct_debit_mandate_code'];
+    if (!array_key_exists($ddCode, $codesMapping)) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate code should be one of the following (0N, 01, 17, 0C)', 900);
+    }
+
+    return $codesMapping[$ddCode];
+  }
+
+  private function getOriginatorNumber() {
+    if (empty($this->rowData['direct_debit_mandate_originator_number'])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Direct Debit Mandate originator number is required for Direct Debit payment plans', 1000);
+    }
+
+    if (!isset($this->cachedValues['originator_numbers'])) {
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'direct_debit_originator_number'";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['originator_numbers'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['originator_numbers'][$this->rowData['direct_debit_mandate_originator_number']])) {
+      return $this->cachedValues['originator_numbers'][$this->rowData['direct_debit_mandate_originator_number']];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException('Invalid direct debit mandate originator number', 1100);
+  }
+
+  private function formatRowDate($dateColumnName, $columnLabel, $isRequired = FALSE) {
+    if ($isRequired && empty($this->rowData[$dateColumnName])) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException("Direct Debit Mandate '{$columnLabel}' is required field.", 1200);
+    }
+
+    if (!empty($this->rowData[$dateColumnName])) {
+      $date = DateTime::createFromFormat('YmdHis', $this->rowData[$dateColumnName]);
+      $date = $date->format('Ymd');
+    }
+    else {
+      $date = new DateTime();
+      $date = $date->format('Ymd');
+    }
+
+    return $date;
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/Exception/InvalidDirectDebitMandateException.php
+++ b/CRM/Membershipextrasimporterapi/Exception/InvalidDirectDebitMandateException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException extends Exception {}

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -214,4 +214,45 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'title' => 'Price Field value Id',
     'type' => CRM_Utils_Type::T_INT,
   ];
+
+  // Direct Debit Mandate
+  $params['direct_debit_mandate_reference'] = [
+    'title' => 'Direct Debit Mandate Reference',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_bank_name'] = [
+    'title' => 'Direct Debit Mandate Bank Name',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_account_holder'] = [
+    'title' => 'Direct Debit Mandate Account Holder Name',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_account_number'] = [
+    'title' => 'Direct Debit Mandate Account Number',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_sort_code'] = [
+    'title' => 'Direct Debit Mandate Sort Code',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_code'] = [
+    'title' => 'Direct Debit Mandate Code',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['direct_debit_mandate_start_date'] = [
+    'title' => 'Direct Debit Mandate Start Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $params['direct_debit_mandate_originator_number'] = [
+    'title' => 'Direct Debit Mandate Originator Number',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
@@ -1,0 +1,373 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate as DirectDebitMandateImporter;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
+
+/**
+ *
+ * @group headless
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest extends BaseHeadlessTest {
+
+  private $sampleRowData = [
+    'payment_plan_payment_processor' => 'Direct Debit',
+    'direct_debit_mandate_reference' => 'Civi00001',
+    'direct_debit_mandate_bank_name' => 'Test Bank',
+    'direct_debit_mandate_account_holder' => 'Test Account Holder',
+    'direct_debit_mandate_account_number' => '12345678',
+    'direct_debit_mandate_sort_code' => '123456',
+    'direct_debit_mandate_code' => '0C',
+    'direct_debit_mandate_start_date' => '20200101000000',
+    'direct_debit_mandate_originator_number' => 'Test Originator',
+  ];
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  private $contributionId;
+
+  private $testOriginatorNumberId;
+
+  public function setUp() {
+    $this->contactId = ContactFabricator::fabricate()['id'];
+
+    $recurContributionParams = ['contact_id' => $this->contactId, 'amount' => 50, 'frequency_interval' => 1, 'payment_processor_id' => 1];
+    $this->recurContributionId = RecurContributionFabricator::fabricate($recurContributionParams)['id'];
+
+    $contributionParams = [
+      'contact_id' => $this->contactId,
+      'financial_type_id' => 'Member Dues',
+      'receive_date' => date('Y-m-d'),
+      'total_amount' => 50,
+      'skipLineItem' => 1,
+      'recur_contribution_id' => $this->recurContributionId,
+    ];
+    $this->contributionId = ContributionFabricator::fabricate($contributionParams)['id'];
+
+    $this->setTestOriginatorNumber();
+  }
+
+  private function setTestOriginatorNumber() {
+    $result = civicrm_api3('OptionValue', 'create', [
+      'sequential' => 1,
+      'option_group_id' => 'direct_debit_originator_number',
+      'label' => 'Test Originator',
+      'name' => 'Test Originator',
+      'value' => 1,
+    ]);
+
+    $this->testOriginatorNumberId = $result['values'][0]['value'];
+  }
+
+  public function testImportWithNoDirectDebitPaymentProcessorWillNotCreateMandate() {
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Paypal';
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $this->assertEmpty($newMandateId);
+  }
+
+  public function testImportWithNoDirectDebitReferenceThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_reference']);
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(100);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportNewDirectDebitMandate() {
+    $beforeImportIds = $this->getMandateIdByReference($this->sampleRowData['direct_debit_mandate_reference']);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $afterImportIds = $this->getMandateIdByReference($this->sampleRowData['direct_debit_mandate_reference']);
+
+    $importSucceed = FALSE;
+    if (empty($beforeImportIds) && $afterImportIds[0] == $newMandateId) {
+      $importSucceed = TRUE;
+    }
+
+    $this->assertTrue($importSucceed);
+  }
+
+  public function testImportWithNoBankNameThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_bank_name']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(200);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectBankNameValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->sampleRowData['direct_debit_mandate_bank_name'], $mandate['bank_name']);
+  }
+
+  public function testImportWithNoAccountHolderThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_account_holder']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(300);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectAccountHolderValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->sampleRowData['direct_debit_mandate_account_holder'], $mandate['account_holder_name']);
+  }
+
+  public function testImportWithNoAccountNumberThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_account_number']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(400);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithAccountNumberMoreThan8CharsThrowException() {
+    $this->sampleRowData['direct_debit_mandate_account_number'] = '123456789';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(500);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithAccountNumberLessThan8CharsThrowException() {
+    $this->sampleRowData['direct_debit_mandate_account_number'] = '1234567';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(500);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectAccountNumberValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->sampleRowData['direct_debit_mandate_account_number'], $mandate['ac_number']);
+  }
+
+  public function testImportWithNoSortCodeThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_sort_code']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(600);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithSortCodeMoreThan6CharsThrowException() {
+    $this->sampleRowData['direct_debit_mandate_sort_code'] = '1234567';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(700);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithSortCodeLessThan6CharsThrowException() {
+    $this->sampleRowData['direct_debit_mandate_sort_code'] = '12345';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(700);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectSortCodeValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->sampleRowData['direct_debit_mandate_sort_code'], $mandate['sort_code']);
+  }
+
+  public function testImportWithNoDDCodeThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_code']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(800);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithInvalidDDCodeThrowException() {
+    $this->sampleRowData['direct_debit_mandate_code'] = 'XYZ';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(900);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectDDCodeValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $code0CId = 4;
+    $this->assertEquals($code0CId, $mandate['dd_code']);
+  }
+
+  public function testImportWithNoStartDateThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_start_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(1200);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectStartDateValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $expectedStartDate = DateTime::createFromFormat('YmdHis', $this->sampleRowData['direct_debit_mandate_start_date']);
+    $this->assertEquals($expectedStartDate->format('Y-m-d 00:00:00'), $mandate['start_date']);
+  }
+
+  public function testImportWithNoOriginatorNumberThrowException() {
+    unset($this->sampleRowData['direct_debit_mandate_originator_number']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(1000);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportWithInvalidOriginatorNumberThrowException() {
+    $this->sampleRowData['direct_debit_mandate_originator_number'] = 'Invalid ON';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
+    $this->expectExceptionCode(1100);
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+  }
+
+  public function testImportSetsCorrectOriginatorNumberValue() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->testOriginatorNumberId, $mandate['originator_number']);
+  }
+
+  public function testImportSetsCorrectContactId() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandate = $this->getMandateById($newMandateId);
+
+    $this->assertEquals($this->contactId, $mandate['entity_id']);
+  }
+
+  public function testImportNewCreatesRecurContributionReferenceRecord() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandates = $this->getMandateRecurContributionReferences();
+
+    $this->assertCount(1, $mandates);
+    $this->assertEquals($newMandateId, $mandates[0]);
+  }
+
+  public function testImportNewCreatesContributionReferenceRecord() {
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $mandates = $this->getMandateContributionReferences();
+
+    $this->assertCount(1, $mandates);
+    $this->assertEquals($newMandateId, $mandates[0]);
+  }
+
+  private function getMandateIdByReference($mandateReference) {
+    $sql = "SELECT id FROM civicrm_value_dd_mandate WHERE dd_ref = %1";
+    $dao = CRM_Core_DAO::executeQuery($sql, [
+      1 => [$mandateReference, 'String'],
+    ]);
+
+    $dao->fetch();
+    if (!empty($dao->id)) {
+      return $dao->id;
+    }
+
+    return NULL;
+  }
+
+  private function getMandateById($mandateId) {
+    $sql = "SELECT * FROM civicrm_value_dd_mandate WHERE id = {$mandateId}";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+
+    $dao->fetch();
+    if (!empty($dao->id)) {
+      return $dao->toArray();
+    }
+
+    return NULL;
+  }
+
+  private function getMandateRecurContributionReferences() {
+    $mandateIds = NULL;
+
+    $sqlQuery = "SELECT mandate_id FROM dd_contribution_recurr_mandate_ref WHERE recurr_id = %1";
+    $mandates = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->recurContributionId, 'Integer']]);
+    while ($mandates->fetch()) {
+      $mandateIds[] = $mandates->mandate_id;
+    }
+
+    return $mandateIds;
+  }
+
+  private function getMandateContributionReferences() {
+    $mandateIds = NULL;
+
+    $sqlQuery = "SELECT mandate_id FROM civicrm_value_dd_information WHERE entity_id = %1";
+    $mandates = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->contributionId, 'Integer']]);
+    while ($mandates->fetch()) {
+      $mandateIds[] = $mandates->mandate_id;
+    }
+
+    return $mandateIds;
+  }
+
+}


### PR DESCRIPTION
This adds new fields to the API endpoint: `MembershipextrasImporter.create`  that allows users to import direct debit mandates and attach them to the imported contributions and recurring contributions.


The new fields are : 

- `Direct Debit Mandate Reference`: Also used to distinguish one mandate from another
- `Direct Debit Mandate Bank Name`
- `Direct Debit Mandate Account Holder Name`
- `Direct Debit Mandate Account Number`: should be 8 characters
- `Direct Debit Mandate Sort Code`: should be 6 characters
- `Direct Debit Mandate Code`
- `Direct Debit Mandate Start Date`
- `Direct Debit Mandate Originator Number`: matched by name


All the above fields are required if the payment plan payment processor is "Direct debit", and if it is not then they will be ignored.

And same as in the manual direct debit extension, the importer will result in inserting records in 3 different tables : 

`civicrm_value_dd_mandate`: the main table contains the mandate information and to which contact it belongs, a contact can have more than one.  the mandate reference field is what the importer use to distinguish one mandate from another.
`dd_contribution_recurr_mandate_ref`: connects the mandate to the recurring contribution, the recurring contribution can only have one mandate attached to it, if the contact has more than one mandate then the last mandate the importer will find in the CSV file will be the one attached to the recurring contribution .
`civicrm_value_dd_information`: connects the mandate to the contribution.

Here are some screenshots from a sample import process and the resulting contribution

![2021-01-26 13_23_58-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/105850754-0bc68180-5fda-11eb-82ea-97e3ab322c05.png)

![2021-01-26 13_24_20-API Import _ compuvag5one](https://user-images.githubusercontent.com/6275540/105850761-0ec17200-5fda-11eb-864c-86d006dd9087.png)


![2021-01-26 13_24_36-dsasda sdaasd _ compuvag5one](https://user-images.githubusercontent.com/6275540/105850767-1123cc00-5fda-11eb-9308-98ed674b844a.png)

![2021-01-26 13_24_51-](https://user-images.githubusercontent.com/6275540/105850773-13862600-5fda-11eb-9083-0cef0c6c7729.png)

![2021-01-26 13_25_07-Calendar](https://user-images.githubusercontent.com/6275540/105850781-15e88000-5fda-11eb-9892-d6a6ec3550d9.png)



and here is the CSV file that was used : 


[V5.zip](https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/files/5873519/V5.zip)


