### PR TITLE
MAE-436: General fixes, updates and improvements

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   run-linters:
 
+    timeout-minutes: 3
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on: pull_request
 jobs:
   run-unit-tests:
 
+    timeout-minutes: 7
+
     runs-on: ubuntu-latest
     container: compucorp/civicrm-buildkit:1.0.0
 

--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -28,8 +28,10 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
     $contributionImporter = new ContributionImporter($this->rowData, $this->contactId, $recurContributionId);
     $contributionId = $contributionImporter->import();
 
-    $membershipPaymentCreator = new MembershipPaymentCreator($membershipId, $contributionId);
-    $membershipPaymentCreator->create();
+    if ($membershipId == NULL) {
+      $membershipPaymentCreator = new MembershipPaymentCreator($membershipId, $contributionId);
+      $membershipPaymentCreator->create();
+    }
 
     $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId);
     $lineItemImporter->import();

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -140,7 +140,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   private function getTotalAmount() {
-    // the total amount will be set as part of line item creation and not here
+    // The total amount will be set as part of line item creation and not here.
     return 0;
   }
 

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -144,7 +144,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   private function getTotalAmount() {
-    //todo : figure out a way to calculate amount, defaulting it to zero for now
+    // the total amount will be set as part of line item creation and not here
     return 0;
   }
 

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -149,8 +149,21 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   private function getCurrency() {
-    // todo : not in mapping document, need to discuss with others how to get it.
-    return 'GBP';
+    if (!isset($this->cachedValues['currencies_enabled'])) {
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'currencies_enabled'";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['currencies_enabled'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['currencies_enabled'][$this->rowData['contribution_currency']])) {
+      return $this->cachedValues['currencies_enabled'][$this->rowData['contribution_currency']];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidContributionFieldException('Invalid or disabled contribution "currency"', 400);
   }
 
   private function calculateIsPayLaterFlag() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -17,10 +17,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   public function import() {
-    if (empty($this->rowData['contribution_external_id'])) {
-      return NULL;
-    }
-
     $contributionId = $this->getContributionIdIfExist();
     if ($contributionId) {
       return $contributionId;

--- a/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandate.php
@@ -49,7 +49,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
       CRM_Core_DAO::executeQuery($sql);
     }
 
-    if (!$this->isMandateContributionRefExist($mandateId)) {
+    if ($this->isDirectDebitContribution() && !$this->isMandateContributionRefExist($mandateId)) {
       $sql = "INSERT INTO `civicrm_value_dd_information` (`mandate_id` , `entity_id`) 
            VALUES ({$mandateId} , {$this->contributionId})";
       CRM_Core_DAO::executeQuery($sql);
@@ -93,6 +93,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
 
     $dao->fetch();
     if (!empty($dao->mandate_id)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function isDirectDebitContribution() {
+    if ($this->rowData['contribution_payment_method'] == 'direct_debit') {
       return TRUE;
     }
 

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -92,6 +92,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $financialItemId = $this->createFinancialItemRecord($lineItemId, $mappedLineItemParams);
     $this->createEntityFinancialTransactionRecord($financialItemId, $mappedLineItemParams['line_total']);
 
+    $this->updateRelatedContributionAmount($mappedLineItemParams['line_total']);
+
     return $lineItemId;
   }
 
@@ -311,6 +313,11 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $dao->fetch();
 
     return $dao->financial_trxn_id;
+  }
+
+  private function updateRelatedContributionAmount($lineItemTotalAmount) {
+    $sqlQuery = "UPDATE `civicrm_contribution` SET `total_amount` = (`total_amount` + %1)";
+    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$lineItemTotalAmount, 'Money']]);
   }
 
 }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -27,7 +27,11 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $this->contributionId = $contributionId;
     $this->membershipId = $membershipId;
     $this->setContribution($contributionId);
-    $this->setMembership($membershipId);
+
+    if ($membershipId != NULL) {
+      $this->setMembership($membershipId);
+    }
+
     $this->setEntityTable();
     $this->setEntityId();
   }
@@ -73,11 +77,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   }
 
   public function import() {
-    $lineItemId = $this->getLineItemIfExist();
-    if ($lineItemId) {
-      return $lineItemId;
-    }
-
     $sqlParams = $this->prepareSqlParams();
     $sqlQuery = $this->prepareSqlQuery($sqlParams);
     CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
@@ -99,24 +98,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $this->updateRelatedContributionAmount($mappedLineItemParams['line_total'], $mappedLineItemParams['tax_amount']);
 
     return $lineItemId;
-  }
-
-  private function getLineItemIfExist() {
-    // todo : What if we have more than one "donation" line item (we probably need to match using price fields)
-    $query = "SELECT id FROM civicrm_line_item WHERE entity_table = %1 AND entity_id = %2 AND contribution_id = %3";
-    $sqlParams = [
-      1 => [$this->entityTable, 'String'],
-      2 => [$this->entityId, 'Integer'],
-      3 => [$this->contributionId, 'Integer'],
-    ];
-    $lineItemId = CRM_Core_DAO::executeQuery($query, $sqlParams);
-    $lineItemId->fetch();
-
-    if (!empty($lineItemId->id)) {
-      return $lineItemId->id;
-    }
-
-    return NULL;
   }
 
   private function prepareSqlParams() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -79,20 +79,24 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     }
 
     $sqlParams = $this->prepareSqlParams();
-    $sql = "INSERT INTO `civicrm_line_item` (`entity_table` , `entity_id` , `contribution_id` , `price_field_id` , `price_field_value_id`,
-            `label` , `qty` , `unit_price` , `line_total` , `financial_type_id`) 
-             VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10)";
-    CRM_Core_DAO::executeQuery($sql, $sqlParams);
+    $sqlQuery = $this->prepareSqlQuery($sqlParams);
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
 
     $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as line_item_id');
     $dao->fetch();
     $lineItemId = $dao->line_item_id;
 
     $mappedLineItemParams = $this->mapLineItemSQLParamsToNames($sqlParams);
+
     $financialItemId = $this->createFinancialItemRecord($lineItemId, $mappedLineItemParams);
     $this->createEntityFinancialTransactionRecord($financialItemId, $mappedLineItemParams['line_total']);
 
-    $this->updateRelatedContributionAmount($mappedLineItemParams['line_total']);
+    if (!empty($mappedLineItemParams['tax_amount'])) {
+      $taxFinancialItemId = $this->createTaxFinancialItemRecord($lineItemId, $mappedLineItemParams);
+      $this->createTaxEntityFinancialTransactionRecord($taxFinancialItemId, $mappedLineItemParams['tax_amount']);
+    }
+
+    $this->updateRelatedContributionAmount($mappedLineItemParams['line_total'], $mappedLineItemParams['tax_amount']);
 
     return $lineItemId;
   }
@@ -124,6 +128,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $unitPrice = $this->getUnitPrice();
     $lineTotal = $this->getLineTotal($unitPrice, $quantity);
     $financialTypeId = $this->getFinancialTypeId();
+    $taxAmount = $this->getTaxAmount();
 
     return [
       1 => [$this->entityTable, 'String'],
@@ -136,10 +141,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
       8 => [$unitPrice, 'Money'],
       9 => [$lineTotal, 'Money'],
       10 => [$financialTypeId, 'Integer'],
+      11 => [$taxAmount, 'Money'],
     ];
   }
 
   private function mapLineItemSQLParamsToNames($contributionSqlParams) {
+    $taxAmount= empty($contributionSqlParams[11][0]) ? 0 : $contributionSqlParams[11][0];
+
     return [
       'entity_table' => $contributionSqlParams[1][0],
       'entity_id' => $contributionSqlParams[2][0],
@@ -151,7 +159,24 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
       'unit_price' => $contributionSqlParams[8][0],
       'line_total' => $contributionSqlParams[9][0],
       'financial_type_id' => $contributionSqlParams[10][0],
+      'tax_amount' => $taxAmount,
     ];
+  }
+
+  private function prepareSqlQuery($sqlParams) {
+    $columnsToInsert = '`entity_table` , `entity_id` , `contribution_id` , `price_field_id` , `price_field_value_id`,
+            `label` , `qty` , `unit_price` , `line_total` , `financial_type_id`';
+
+    $columnsValuesIndexes = '%1, %2, %3, %4, %5, %6, %7, %8, %9, %10';
+
+    $isThereTax = !empty($sqlParams[11][0]);
+    if ($isThereTax) {
+      $columnsToInsert .= ', `tax_amount`';
+      $columnsValuesIndexes .= ', %11';
+    }
+
+    return "INSERT INTO `civicrm_line_item` ({$columnsToInsert})
+             VALUES ({$columnsValuesIndexes})";
   }
 
   private function setPriceFieldValueDetails() {
@@ -230,13 +255,25 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     throw new CRM_Membershipextrasimporterapi_Exception_InvalidLineItemException('Invalid line item "Financial Type"', 200);
   }
 
+  private function getTaxAmount() {
+    if (!empty($this->rowData['line_item_tax_amount'])) {
+      return $this->rowData['line_item_tax_amount'];
+    }
+
+    return 0;
+  }
+
   private function createFinancialItemRecord($lineItemId, $mappedLineItemParams) {
+    // This is reserved value for income account relationship and will always equal such value on any CiviCRM site
+    $incomeAccountRelationshipId = 1;
+    $toFinancialAccountId = $this->getFinancialAccountIdByRelationship($mappedLineItemParams['financial_type_id'], $incomeAccountRelationshipId);
+
     $sqlParams = [
       1 => [$this->contribution['contact_id'], 'Integer'],
       2 => [$mappedLineItemParams['line_item_label'], 'String'],
       3 => [$mappedLineItemParams['line_total'], 'Money'],
       4 => [$this->contribution['currency'], 'String'],
-      5 => [$this->getToFinancialAccountId($mappedLineItemParams['financial_type_id']), 'Integer'],
+      5 => [$toFinancialAccountId, 'Integer'],
       6 => [$this->getFinancialItemStatusId(), 'Integer'],
       7 => ['civicrm_line_item', 'String'],
       8 => [$lineItemId, 'Integer'],
@@ -253,12 +290,36 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     return $dao->id;
   }
 
-  private function getToFinancialAccountId($financialTypeId) {
-    // This is reserved value and will always equal such value on any CiviCRM site
-    $incomeAccountRelationshipId = 1;
+  private function createTaxFinancialItemRecord($lineItemId, $mappedLineItemParams) {
+    // This is reserved value for sales account relationship and will always equal such value on any CiviCRM site
+    $salesTaxAccountRelationshipId = 10;
+    $toFinancialAccountId = $this->getFinancialAccountIdByRelationship($mappedLineItemParams['financial_type_id'], $salesTaxAccountRelationshipId);
 
+    $sqlParams = [
+      1 => [$this->contribution['contact_id'], 'Integer'],
+      2 => ['Sales Tax', 'String'],
+      3 => [$mappedLineItemParams['tax_amount'], 'Money'],
+      4 => [$this->contribution['currency'], 'String'],
+      5 => [$toFinancialAccountId, 'Integer'],
+      6 => [$this->getFinancialItemStatusId(), 'Integer'],
+      7 => ['civicrm_line_item', 'String'],
+      8 => [$lineItemId, 'Integer'],
+      9 => [$this->contribution['receive_date'], 'String'],
+    ];
+    $sqlQuery = "INSERT INTO `civicrm_financial_item` (`contact_id` , `description` , `amount` , `currency` ,
+                 `financial_account_id` , `status_id` , `entity_table` , `entity_id`, `transaction_date`) 
+                 VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as id');
+    $dao->fetch();
+
+    return $dao->id;
+  }
+
+  private function getFinancialAccountIdByRelationship($financialTypeId, $accountRelationship) {
     $sqlQuery = "SELECT financial_account_id FROM civicrm_entity_financial_account 
-                   WHERE entity_table = 'civicrm_financial_type' AND entity_id = {$financialTypeId} AND account_relationship = {$incomeAccountRelationshipId}";
+                   WHERE entity_table = 'civicrm_financial_type' AND entity_id = {$financialTypeId} AND account_relationship = {$accountRelationship}";
     $result = CRM_Core_DAO::executeQuery($sqlQuery);
     $result->fetch();
 
@@ -308,16 +369,44 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
   }
 
+  private function createTaxEntityFinancialTransactionRecord($financialItemId, $taxAmount) {
+    $sqlParams = [
+      1 => ['civicrm_financial_item', 'String'],
+      2 => [$financialItemId, 'Integer'],
+      3 => [$this->getContributionFinancialTrxnId(), 'Integer'],
+      4 => [$taxAmount, 'Money'],
+    ];
+    $sqlQuery = "INSERT INTO `civicrm_entity_financial_trxn` (`entity_table` , `entity_id` , `financial_trxn_id` , `amount`) 
+                 VALUES (%1, %2, %3, %4)";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+  }
+
   private function getContributionFinancialTrxnId() {
+    if (!empty($this->cachedValues['contribution_financial_trxn_Id'])) {
+      return $this->cachedValues['contribution_financial_trxn_Id'];
+    }
+
     $dao = CRM_Core_DAO::executeQuery("SELECT financial_trxn_id FROM civicrm_entity_financial_trxn WHERE entity_table = 'civicrm_contribution' AND entity_id = {$this->contributionId} LIMIT 1");
     $dao->fetch();
+
+    $this->cachedValues['contribution_financial_trxn_Id'] = $dao->financial_trxn_id;
 
     return $dao->financial_trxn_id;
   }
 
-  private function updateRelatedContributionAmount($lineItemTotalAmount) {
-    $sqlQuery = "UPDATE `civicrm_contribution` SET `total_amount` = (`total_amount` + %1)";
-    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$lineItemTotalAmount, 'Money']]);
+  private function updateRelatedContributionAmount($lineItemTotalAmount, $taxAmount) {
+    $totalAmount = $lineItemTotalAmount + $taxAmount;
+
+    $amountFieldOperation = '`total_amount` = `total_amount` + %1';
+    $sqlParams[1] = [$totalAmount, 'Money'];
+
+    if (!empty($taxAmount)) {
+      $amountFieldOperation .= ', `tax_amount` = IFNULL(`tax_amount`, 0) + %2';
+      $sqlParams[2] = [$taxAmount, 'Money'];
+    }
+
+    $sqlQuery = "UPDATE `civicrm_contribution` SET {$amountFieldOperation} WHERE id = {$this->contributionId}";
+    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
   }
 
 }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -95,7 +95,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
       $this->createTaxEntityFinancialTransactionRecord($taxFinancialItemId, $mappedLineItemParams['tax_amount']);
     }
 
-    $this->updateRelatedContributionAmount($mappedLineItemParams['line_total'], $mappedLineItemParams['tax_amount']);
+    $this->updateRelatedContributionAmounts($mappedLineItemParams['line_total'], $mappedLineItemParams['tax_amount']);
 
     return $lineItemId;
   }
@@ -375,7 +375,25 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     return $dao->financial_trxn_id;
   }
 
-  private function updateRelatedContributionAmount($lineItemTotalAmount, $taxAmount) {
+  /**
+   * Updates the contribution amounts.
+   *
+   * Here we update both the contribution
+   * total amount and tax amount, the mechanism
+   * to do so is by keeping adding the line
+   * item amounts we currently processing
+   * to the related contribution amounts ,
+   * since line items are processed row by row and
+   * there is no way to know the total amount in advance.
+   *
+   * Hence that the total amount is both the
+   * the amount + the tax amount same as in
+   * CiviCRM core.
+   *
+   * @param float $lineItemTotalAmount
+   * @param float $taxAmount
+   */
+  private function updateRelatedContributionAmounts($lineItemTotalAmount, $taxAmount) {
     $totalAmount = $lineItemTotalAmount + $taxAmount;
 
     $amountFieldOperation = '`total_amount` = `total_amount` + %1';

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -127,7 +127,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   }
 
   private function mapLineItemSQLParamsToNames($contributionSqlParams) {
-    $taxAmount= empty($contributionSqlParams[11][0]) ? 0 : $contributionSqlParams[11][0];
+    $taxAmount = empty($contributionSqlParams[11][0]) ? 0 : $contributionSqlParams[11][0];
 
     return [
       'entity_table' => $contributionSqlParams[1][0],

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -17,10 +17,15 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
   }
 
   public function import() {
-    if (empty($this->rowData['membership_external_id'])) {
-      // todo : when the line item importer is created,
-      // we need to throw an exception if this field  is not set and line_item.entity_table = "civicrm_membership"
+    $membershipExternalIdSet = !empty($this->rowData['membership_external_id']);
+    $isMembershipLineItem = $this->rowData['line_item_entity_table'] == 'civicrm_membership';
+
+    if (!$isMembershipLineItem) {
       return NULL;
+    }
+
+    if (!$membershipExternalIdSet) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException('Membership external id is required for membership line items', 600);
     }
 
     $membershipId = $this->getMembershipIdIfExist();

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -17,13 +17,18 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
   }
 
   public function import() {
-    $membershipExternalIdSet = !empty($this->rowData['membership_external_id']);
     $isMembershipLineItem = $this->rowData['line_item_entity_table'] == 'civicrm_membership';
-
     if (!$isMembershipLineItem) {
       return NULL;
     }
 
+    // If the membership id is supplied in the CSV as part of the line item entity_id
+    // then we just return it
+    if (!empty($this->rowData['line_item_entity_id'])) {
+      return $this->rowData['line_item_entity_id'];
+    }
+
+    $membershipExternalIdSet = !empty($this->rowData['membership_external_id']);
     if (!$membershipExternalIdSet) {
       throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException('Membership external id is required for membership line items', 600);
     }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -150,7 +150,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
       throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException("Membership status override end date should be provided if the membership is 'Override Until Date'.", 500);
     }
 
-
     if (!empty($statusOverrideEndDate)) {
       return CRM_Member_StatusOverrideTypes::UNTIL_DATE;
     }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -139,6 +139,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
   }
 
   private function isOverriddenStatus($statusOverrideEndDate) {
+    if (!empty($this->rowData['membership_is_status_overridden']) &&
+      $this->rowData['membership_is_status_overridden'] == CRM_Member_StatusOverrideTypes::UNTIL_DATE &&
+      empty($statusOverrideEndDate)) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException("Membership status override end date should be provided if the membership is 'Override Until Date'.", 500);
+    }
+
+
     if (!empty($statusOverrideEndDate)) {
       return CRM_Member_StatusOverrideTypes::UNTIL_DATE;
     }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -108,8 +108,21 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   }
 
   private function getCurrency() {
-    // todo : not in mapping document, need to discuss with others how to get it.
-    return 'GBP';
+    if (!isset($this->cachedValues['currencies_enabled'])) {
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+                  WHERE cog.name = 'currencies_enabled'";
+      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      while ($result->fetch()) {
+        $this->cachedValues['currencies_enabled'][$result->name] = $result->id;
+      }
+    }
+
+    if (!empty($this->cachedValues['currencies_enabled'][$this->rowData['payment_plan_currency']])) {
+      return $this->cachedValues['currencies_enabled'][$this->rowData['payment_plan_currency']];
+    }
+
+    throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Invalid or disabled payment plan "currency"', 900);
   }
 
   private function calculateFrequencyParameters() {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -183,6 +183,18 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
     throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Invalid payment plan "Status"', 200);
   }
 
+  /**
+   * Returns the payment processor id.
+   * Hence that only payment processors
+   * that implements Payment_Manual class
+   * are allowed, since the importer will
+   * only be used with offline payment
+   * processors.
+   *
+   * @return mixed
+   *
+   * @throws CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException
+   */
   private function getPaymentProcessorId() {
     if (!isset($this->cachedValues['payment_processors'])) {
       $sqlQuery = "SELECT id, name, class_name FROM civicrm_payment_processor WHERE is_test = 0 AND is_active = 1";
@@ -194,7 +206,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
 
     $paymentProcessorName = $this->rowData['payment_plan_payment_processor'];
     if (!empty($this->cachedValues['payment_processors'][$paymentProcessorName])) {
-      if ($this->cachedValues['payment_processors'][$paymentProcessorName]['class_name'] != 'Payment_Manual') {
+      $offlinePaymentProcessorClassName = 'Payment_Manual';
+      if ($this->cachedValues['payment_processors'][$paymentProcessorName]['class_name'] != $offlinePaymentProcessorClassName) {
         throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Only Manual payment plan "Payment Processors"', 1200);
       }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Membershipextras Importer API
 
-This extension creates new API Endpoint [TODO: put API Endpoint name here], that can be used within [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension,
+This extension creates new API Endpoint `MembershipextrasImporter`, that can be used within [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension,
 and allows importing Payment Plan membership orders and direct debit information for the use of Membershipextras suite.
 
 # Dependencies
@@ -13,3 +13,8 @@ And optionally :
 - [Manual Direct debit extension](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit) : In case you have payment plan orders paid with Direct debit.
 
 
+It also requires the following custom groups and their custom fields to be activated : 
+
+- Recurring Contribution External ID
+- Contribution External ID
+- Membership External ID

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -209,7 +209,7 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
 
   $params['line_item_tax_amount'] = [
     'title' => 'Order Line Tax Amount',
-    'type' => CRM_Utils_Type::T_STRING,
+    'type' => CRM_Utils_Type::T_MONEY,
   ];
 
   $params['line_item_auto_renew'] = [

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -41,6 +41,12 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'type' => CRM_Utils_Type::T_MONEY,
   ];
 
+  $params['payment_plan_currency'] = [
+    'title' => 'Payment Plan Currency',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
   $params['payment_plan_frequency'] = [
     'title' => 'Payment Plan Frequency',
     'type' => CRM_Utils_Type::T_STRING,
@@ -140,6 +146,12 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
 
   $params['contribution_financial_type'] = [
     'title' => 'Contribution Financial Type',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $params['contribution_currency'] = [
+    'title' => 'Contribution Currency',
     'type' => CRM_Utils_Type::T_STRING,
     'api.required' => 1,
   ];

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
@@ -16,7 +16,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends Ba
     'contribution_payment_method' => 'EFT',
     'contribution_received_date' => '20190101013040',
     'contribution_status' => 'Pending',
-    'contribution_currency'=> 'USD',
+    'contribution_currency' => 'USD',
   ];
 
   private $contactId;

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
@@ -13,6 +13,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
 
   private $sampleRowData = [
     'payment_plan_payment_processor' => 'Direct Debit',
+    'contribution_payment_method' => 'direct_debit',
     'direct_debit_mandate_reference' => 'Civi00001',
     'direct_debit_mandate_bank_name' => 'Test Bank',
     'direct_debit_mandate_account_holder' => 'Test Account Holder',
@@ -318,6 +319,17 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
 
     $this->assertCount(1, $mandates);
     $this->assertEquals($newMandateId, $mandates[0]);
+  }
+
+  public function testImportWillNotCreateContributionReferenceRecordIfContributionPaymentMethodIsNotDirectDebit() {
+    $this->sampleRowData['contribution_payment_method'] = 'EFT';
+
+    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter->import();
+
+    $mandates = $this->getMandateContributionReferences();
+
+    $this->assertNull($mandates);
   }
 
   private function getMandateIdByReference($mandateReference) {

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
@@ -107,16 +107,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
     $lineItemImporter->import();
   }
 
-  public function testImportExistingLineItemWillNotCreateNewOne() {
-    $lineItemImporter = new LineItemImporter($this->sampleRowData, $this->contributionId, $this->membershipId);
-    $firstLineItemId = $lineItemImporter->import();
-
-    $lineItemImporter = new LineItemImporter($this->sampleRowData, $this->contributionId, $this->membershipId);
-    $secondLineItemId = $lineItemImporter->import();
-
-    $this->assertEquals($firstLineItemId, $secondLineItemId);
-  }
-
   public function testImportMembershipLineItemWithEntityIdNotSetWillDefaultItToMembershipId() {
     $this->sampleRowData['line_item_entity_table'] = 'civicrm_membership';
 

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -12,6 +12,7 @@ use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabrica
 class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends BaseHeadlessTest {
 
   private $sampleRowData = [
+    'line_item_entity_table' => 'civicrm_membership',
     'membership_external_id' => 'test1',
     'membership_type' => 'Student',
     'membership_join_date' => '20180101000000',
@@ -275,6 +276,26 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
     $this->expectExceptionCode(500);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
+  public function testImportForNonMembershipLineItemWillNotCreateMembership() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test20';
+    $this->sampleRowData['line_item_entity_table'] = 'civicrm_contribution';
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipId = $membershipImporter->import();
+
+    $this->assertNull($membershipId);
+  }
+
+  public function testImportWithNoExternalIdThrowException() {
+    unset($this->sampleRowData['membership_external_id']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(600);
 
     $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $membershipImporter->import();

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -269,6 +269,17 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
     $this->assertEquals('2030-01-01', $newMembership['status_override_end_date']);
   }
 
+  public function testImportWithOverrideUntilDateButWithNoEndDateForTheStatusThrowException() {
+    $this->sampleRowData['membership_external_id'] = 'test19';
+    $this->sampleRowData['membership_is_status_overridden'] = CRM_Member_StatusOverrideTypes::UNTIL_DATE;
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidMembershipFieldException::class);
+    $this->expectExceptionCode(500);
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipImporter->import();
+  }
+
   private function getMembershipsByContactId($contactId) {
     $membershipIds = NULL;
 

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -282,7 +282,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
   }
 
   public function testImportForNonMembershipLineItemWillNotCreateMembership() {
-    $this->sampleRowData['payment_plan_external_id'] = 'test20';
+    $this->sampleRowData['membership_external_id'] = 'test20';
     $this->sampleRowData['line_item_entity_table'] = 'civicrm_contribution';
 
     $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
@@ -299,6 +299,15 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
     $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $membershipImporter->import();
+  }
+
+  public function testImportWithLineItemEntityIdSetWillReturnItInsteadOfCreatingMembership() {
+    $this->sampleRowData['line_item_entity_id'] = 5580;
+
+    $membershipImporter = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $membershipId = $membershipImporter->import();
+
+    $this->assertEquals($this->sampleRowData['line_item_entity_id'], $membershipId);
   }
 
   private function getMembershipsByContactId($contactId) {

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -441,6 +441,50 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     $this->assertEquals($this->sampleRowData['payment_plan_currency'], $newRecurContribution['currency']);
   }
 
+  public function testImportDirectDebitPaymentPlanShouldHaveBothPaymentProcessorAndPaymentMethodAsDirectDebit() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test34';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Direct Debit';
+    $this->sampleRowData['payment_plan_payment_method'] = 'direct_debit';
+
+    $beforeImportIds = $this->getRecurContributionsByContactId($this->contactId);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $afterImportIds = $this->getRecurContributionsByContactId($this->contactId);
+
+    $importSucceed = FALSE;
+    if (empty($beforeImportIds) && $afterImportIds[0] == $newRecurContributionId) {
+      $importSucceed = TRUE;
+    }
+
+    $this->assertTrue($importSucceed);
+  }
+
+  public function testImportDirectDebitPaymentPlanWithPaymentMethodThatIsNotDirectDebitThrowException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test35';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Direct Debit';
+    $this->sampleRowData['payment_plan_payment_method'] = 'EFT';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(1000);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportDirectDebitPaymentPlanWithPaymentProcessorThatIsNotDirectDebitThrowException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test35';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Paypal';
+    $this->sampleRowData['payment_plan_payment_method'] = 'direct_debit';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(1100);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
   private function getRecurContributionsByContactId($contactId) {
     $recurContributionIds = NULL;
 

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -21,6 +21,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     'payment_plan_financial_type' => 'Member Dues',
     'payment_plan_payment_method' => 'EFT',
     'payment_plan_status' => 'Pending',
+    'payment_plan_currency'=> 'USD',
   ];
 
   private $contactId;
@@ -404,6 +405,40 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
     $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
     $recurContributionImporter->import();
+  }
+
+  public function testImportWithInvalidCurrencyThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test31';
+    $this->sampleRowData['payment_plan_currency'] = 'FAKE';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(900);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWithInactiveCurrencyWillThrowAnException() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test32';
+    $this->sampleRowData['payment_plan_currency'] = 'JOD';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(900);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportSetsCorrectCurrencyValue() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test33';
+    $this->sampleRowData['payment_plan_currency'] = 'USD';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $newRecurContribution = $this->getRecurContributionsById($newRecurContributionId);
+
+    $this->assertEquals($this->sampleRowData['payment_plan_currency'], $newRecurContribution['currency']);
   }
 
   private function getRecurContributionsByContactId($contactId) {

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -21,7 +21,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     'payment_plan_financial_type' => 'Member Dues',
     'payment_plan_payment_method' => 'EFT',
     'payment_plan_status' => 'Pending',
-    'payment_plan_currency'=> 'USD',
+    'payment_plan_currency' => 'USD',
   ];
 
   private $contactId;

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -475,11 +475,31 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportDirectDebitPaymentPlanWithPaymentProcessorThatIsNotDirectDebitThrowException() {
     $this->sampleRowData['payment_plan_external_id'] = 'test35';
-    $this->sampleRowData['payment_plan_payment_processor'] = 'Paypal';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Offline Recurring Contribution';
     $this->sampleRowData['payment_plan_payment_method'] = 'direct_debit';
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
     $this->expectExceptionCode(1100);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testImportWithNonManualPaymentProcessorThrowException() {
+    civicrm_api3('PaymentProcessor', 'create', [
+      'payment_processor_type_id' => 'Dummy',
+      'financial_account_id' => 'Payment Processor Account',
+      'name' => 'Test Processor',
+      'is_active' => 1,
+      'is_test' => 0,
+      'class_name' => 'Payment_Dummy',
+    ]);
+
+    $this->sampleRowData['payment_plan_external_id'] = 'test36';
+    $this->sampleRowData['payment_plan_payment_processor'] = 'Test Processor';
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(1200);
 
     $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
     $recurContributionImporter->import();


### PR DESCRIPTION
## Overview

As part of this PR, I am doing several fixes, updates and improvements to the importer, these are : 

1- Adding required currency fields for both the recurring contribution (Payment Plan Currency) and for the contribution (Contribution Currency).

2- Adding validation to confirm that : 

A- If the payment plan payment processor is "direct debit" then the payment method  (instrument)  is also "direct debit"
B-  If the payment plan payment method (instrument) is "direct debit" then the payment processor  is also "direct debit"

3- Updating the contribution amount to equal the sum of its line items.

4- Adding validation to confirm that "membership status override end date" is supplied if "is status overridden" equals 2 (which means that the membership status is overridden until date.

5- Also in this PR I am adding the functionally to actually import the tax fields that were added in previous PR, I set the tax for two entities : 

A-**Line item**: I store the tax (if given)  amount as provided in the CSV file inside tax_amount field inside the civicrm_line_item table, where I keep the line total and unit price as is without adding the tax to them similar to how CiviCRM core work.

B- **Contribution**:  I add the tax to the contribution amount, and I also store it inside civicrm_contribution.tax_amount field, same as in CiviCRM core.

C- And same as in core, I create separate financial records (civicrm_financial_item & civicrm_entity_financial_trxn) for the tax amount.


6- I also added validation to confirm that only payment plans paid using Payment Processor that implements CiviCRM `Payment_Manual` class are allowed (Such as Direct Debit and Offline recurring contribution payment processors).

7- I also did some changes and validations to the LineItem importer to make sure it can import donation line items especially if there is more than. One of these changes is that I no longer check if the line item already exists, the reason is that we don't have an external identifier for the line item, and it is hard to know if the line item already exists especially if there is more than one donation line item, it also make sense because each line in the CSV importer should represent a separate line item, so it should be safe to just create the line item without validating if it is already created or not.

8- I added validation to confirm that the membership external id is provided if the order line item is a membership line item.

9- I ensured that Contribution mandate reference is only created for contributions that have "payment method" = Direct debit.

10- And finally I updated the membership importer to return early if the line item entity id is Set, since that will be the membership id.
