### PR TITLE
MAE-462: Recurring contribution and subscription line items updates

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -33,7 +33,7 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
       $membershipPaymentCreator->create();
     }
 
-    $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId);
+    $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId, $recurContributionId);
     $lineItemImporter->import();
 
     $mandateImporter = new DirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -37,6 +37,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
     $dao->fetch();
     $recurContributionId = $dao->recur_contribution_id;
 
+    $this->setActiveStatus($recurContributionId);
+
     $sqlQuery = "INSERT INTO `civicrm_value_contribution_recur_ext_id` (`entity_id` , `external_id`) 
            VALUES ({$recurContributionId}, %1)";
     CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
@@ -289,6 +291,20 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
     }
 
     return $date;
+  }
+
+  private function setActiveStatus($recurContributionId) {
+    $isActive = 0;
+    if (!empty($this->rowData['payment_plan_is_active'])) {
+      $isActive = 1;
+    }
+
+    $activationQuery = "
+      INSERT INTO civicrm_value_payment_plan_extra_attributes  
+      (entity_id, is_active) VALUES ({$recurContributionId}, {$isActive}) 
+      ON DUPLICATE KEY UPDATE is_active = {$isActive} 
+     ";
+    CRM_Core_DAO::executeQuery($activationQuery);
   }
 
 }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -111,11 +111,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   }
 
   private function getAmount() {
+    $amount = 0;
     if (!empty($this->rowData['payment_plan_total_amount'])) {
       $amount = $this->rowData['payment_plan_total_amount'];
-    }
-    else {
-      // todo : if null we default this to the total amount of the instalment with the most future date. but how to do that ?
     }
 
     return $amount;

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -96,6 +96,11 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'api.required' => 1,
   ];
 
+  $params['payment_plan_is_active'] = [
+    'title' => 'Payment Plan Is Active?',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
   // Membership
   $params['membership_external_id'] = [
     'title' => 'Membership External Id',

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
@@ -477,7 +477,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
     $lineItemImporter = new LineItemImporter($this->sampleRowData, $this->contributionId, $this->membershipId, $this->recurContributionId);
     $lineItemImporter->import();
 
-
     $sqlQuery = "SELECT msl.id as id  
                  FROM membershipextras_subscription_line msl 
                  INNER JOIN civicrm_line_item cli ON msl.line_item_id = cli.id 
@@ -495,7 +494,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
 
     $lineItemImporter = new LineItemImporter($this->sampleRowData, $this->contributionId, $this->membershipId, $this->recurContributionId);
     $lineItemImporter->import();
-
 
     $sqlQuery = "SELECT msl.id as id  
                  FROM membershipextras_subscription_line msl 

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -505,6 +505,33 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     $recurContributionImporter->import();
   }
 
+  public function testImportWillSetDefaultActiveStatusToFalse() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test37';
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $sqlQuery = "SELECT is_active FROM civicrm_value_payment_plan_extra_attributes WHERE entity_id = {$newRecurContributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+
+    $this->assertEquals(0, $result->is_active);
+  }
+
+  public function testImportWillSetActiveStatus() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test37';
+    $this->sampleRowData['payment_plan_is_active'] = 1;
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $sqlQuery = "SELECT is_active FROM civicrm_value_payment_plan_extra_attributes WHERE entity_id = {$newRecurContributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+
+    $this->assertEquals(1, $result->is_active);
+  }
+
   private function getRecurContributionsByContactId($contactId) {
     $recurContributionIds = NULL;
 


### PR DESCRIPTION
## Before
The importer so far will import and create all the needed records and entities, but so far it is missing three things : 

1- How to set the contribution recurring amount, according to the specs; it should be based on the latest contribution (instalment) amount, but there are two problems with this : 

A- We need to guarantee that the records in the CSV file are ordered from the oldest to the newest contribution. 
B- And even if we guarantee that, how can we know the amount given that we process one line item per CSV row/ API call, which make it hard to know which is the last instalment since we don't know if there are more instalments to process.

2- Subscription line items, which should be created only for one recurring contribution instalment, so if we have like 12 instalments, only the first instalment (or the last) should have subscription line items same as in Membershipextras extension. Without them, we won't be able to use the manage instalments screen.

3- Also we don't set "Related Payment Plan Periods" custom group fields so far which is important for autorenewal and other functions, though this custom group is replaced with a new custom field called "Is Active" in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/355 that we are not filling yet as part of the import process.

## After

So each of these problems are solved in different ways, which include changes in how the CSV should look like, and others in how Membershipextras work, and the rest of these changes are in this PR. 

- For issue 1, we now consider only the last payment plan instalment line items should have the "Auto Renew" field set in the CSV, and thus, the importer will only add the amounts from these line items to the recurring contribution.
- For issue 2, and as with issue 1, given that we now assume that only the last instalment line items should have "Auto Renew" set, so we now create subscription line items only for these line items.
- While issue 3 is kinda fixed and explained here: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/355 , and in this PR I am only adding the "Payment Plan Is active?" mapping field to the API, and inserting the value for this field as supplied by the CSV.