### PR TITLE
MAE-505: Fixes and improvements

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -6,6 +6,7 @@ use CRM_Membershipextrasimporterapi_EntityImporter_Contribution as ContributionI
 use CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment as MembershipPaymentCreator;
 use CRM_Membershipextrasimporterapi_EntityImporter_LineItem as LineItemImporter;
 use CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate as DirectDebitMandateImporter;
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
 
 class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
@@ -45,7 +46,7 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
     if (!empty($this->rowData['contact_id'])) {
       $sqlQuery = "SELECT id FROM civicrm_contact WHERE id = %1";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contact_id'], 'Integer']]);
+      $result = SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['contact_id'], 'Integer']]);
       if (!$result->fetch()) {
         throw new CRM_Membershipextrasimporterapi_Exception_InvalidContactException("Cannot find contact with Id = $this->rowData['contact_id']", 100);
       }
@@ -55,7 +56,7 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
 
     if (!empty($this->rowData['contact_external_id'])) {
       $sqlQuery = "SELECT id FROM civicrm_contact WHERE external_identifier = %1";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['contact_external_id'], 'String']]);
+      $result = SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['contact_external_id'], 'String']]);
       if (!$result->fetch()) {
         throw new CRM_Membershipextrasimporterapi_Exception_InvalidContactException("Cannot find contact with External Id = $this->rowData['contact_external_id']", 200);
       }

--- a/CRM/Membershipextrasimporterapi/EntityCreator/MembershipPayment.php
+++ b/CRM/Membershipextrasimporterapi/EntityCreator/MembershipPayment.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
+
 class CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment {
 
   private $membershipId;
@@ -23,14 +25,14 @@ class CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment {
     }
 
     $sqlQuery = "INSERT INTO civicrm_membership_payment (membership_id, contribution_id) VALUES ({$this->membershipId}, {$this->contributionId})";
-    CRM_Core_DAO::executeQuery($sqlQuery);
+    SQLQueryRunner::executeQuery($sqlQuery);
 
     return TRUE;
   }
 
   private function isRecordAlreadyCreated() {
     $sqlQuery = "SELECT id FROM civicrm_membership_payment WHERE membership_id = {$this->membershipId} AND contribution_id = {$this->contributionId}";
-    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result = SQLQueryRunner::executeQuery($sqlQuery);
     if ($result->fetch()) {
       return TRUE;
     }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
 
 class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
@@ -40,13 +41,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   }
 
   private function setContribution($contributionId) {
-    $dao = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_contribution WHERE id = {$contributionId}");
+    $dao = SQLQueryRunner::executeQuery("SELECT * FROM civicrm_contribution WHERE id = {$contributionId}");
     $dao->fetch();
     $this->contribution = $dao->toArray();
   }
 
   private function setMembership($membershipId) {
-    $dao = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_membership WHERE id = {$membershipId}");
+    $dao = SQLQueryRunner::executeQuery("SELECT * FROM civicrm_membership WHERE id = {$membershipId}");
     $dao->fetch();
     $this->membership = $dao->toArray();
   }
@@ -82,9 +83,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   public function import() {
     $sqlParams = $this->prepareSqlParams();
     $sqlQuery = $this->prepareSqlQuery($sqlParams);
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as line_item_id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as line_item_id');
     $dao->fetch();
     $lineItemId = $dao->line_item_id;
 
@@ -200,9 +201,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
 
     $sqlParams = $this->prepareDuplicateLineItemSqlParams($mappedLineItemParams);
     $sqlQuery = $this->prepareDuplicateLineItemSqlQuery($sqlParams);
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as line_item_id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as line_item_id');
     $dao->fetch();
     $duplicateLineItemId = $dao->line_item_id;
 
@@ -222,7 +223,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     ];
     $sqlQuery = "INSERT INTO `membershipextras_subscription_line` (`contribution_recur_id` , `line_item_id`, `start_date`, `auto_renew`) 
                  VALUES (%1, %2, %3, %4)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
   private function prepareDuplicateLineItemSqlParams($mappedLineItemParams) {
@@ -283,7 +284,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   }
 
   private function getPriceFieldValueDetailsById($priceFieldValueId) {
-    $dao = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_price_field_value WHERE id = {$priceFieldValueId}");
+    $dao = SQLQueryRunner::executeQuery("SELECT * FROM civicrm_price_field_value WHERE id = {$priceFieldValueId}");
     $dao->fetch();
 
     return $dao->toArray();
@@ -291,7 +292,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
 
   private function getMembershipPriceFieldValueDetails() {
     $membershipTypeId = $this->membership['membership_type_id'];
-    $dao = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_price_field_value WHERE membership_type_id = {$membershipTypeId} 
+    $dao = SQLQueryRunner::executeQuery("SELECT * FROM civicrm_price_field_value WHERE membership_type_id = {$membershipTypeId} 
                                        ORDER BY id ASC LIMIT 1");
     $dao->fetch();
 
@@ -330,7 +331,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   private function getFinancialTypeId() {
     if (!isset($this->cachedValues['financial_types'])) {
       $sqlQuery = "SELECT id, name FROM civicrm_financial_type";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['financial_types'][$result->name] = $result->id;
       }
@@ -370,9 +371,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $sqlQuery = "INSERT INTO `civicrm_financial_item` (`contact_id` , `description` , `amount` , `currency` ,
                  `financial_account_id` , `status_id` , `entity_table` , `entity_id`, `transaction_date`) 
                  VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as id');
     $dao->fetch();
 
     return $dao->id;
@@ -397,9 +398,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $sqlQuery = "INSERT INTO `civicrm_financial_item` (`contact_id` , `description` , `amount` , `currency` ,
                  `financial_account_id` , `status_id` , `entity_table` , `entity_id`, `transaction_date`) 
                  VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as id');
     $dao->fetch();
 
     return $dao->id;
@@ -408,7 +409,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   private function getFinancialAccountIdByRelationship($financialTypeId, $accountRelationship) {
     $sqlQuery = "SELECT financial_account_id FROM civicrm_entity_financial_account 
                    WHERE entity_table = 'civicrm_financial_type' AND entity_id = {$financialTypeId} AND account_relationship = {$accountRelationship}";
-    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result = SQLQueryRunner::executeQuery($sqlQuery);
     $result->fetch();
 
     return $result->financial_account_id;
@@ -454,7 +455,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     ];
     $sqlQuery = "INSERT INTO `civicrm_entity_financial_trxn` (`entity_table` , `entity_id` , `financial_trxn_id` , `amount`) 
                  VALUES (%1, %2, %3, %4)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
   private function createTaxEntityFinancialTransactionRecord($financialItemId, $taxAmount) {
@@ -466,7 +467,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     ];
     $sqlQuery = "INSERT INTO `civicrm_entity_financial_trxn` (`entity_table` , `entity_id` , `financial_trxn_id` , `amount`) 
                  VALUES (%1, %2, %3, %4)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
   private function getContributionFinancialTrxnId() {
@@ -474,7 +475,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
       return $this->cachedValues['contribution_financial_trxn_Id'];
     }
 
-    $dao = CRM_Core_DAO::executeQuery("SELECT financial_trxn_id FROM civicrm_entity_financial_trxn WHERE entity_table = 'civicrm_contribution' AND entity_id = {$this->contributionId} LIMIT 1");
+    $dao = SQLQueryRunner::executeQuery("SELECT financial_trxn_id FROM civicrm_entity_financial_trxn WHERE entity_table = 'civicrm_contribution' AND entity_id = {$this->contributionId} LIMIT 1");
     $dao->fetch();
 
     $this->cachedValues['contribution_financial_trxn_Id'] = $dao->financial_trxn_id;
@@ -512,7 +513,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     }
 
     $sqlQuery = "UPDATE `civicrm_contribution` SET {$amountFieldOperation} WHERE id = {$this->contributionId}";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
   /**
@@ -543,7 +544,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $sqlParams[1] = [$totalAmount, 'Money'];
 
     $sqlQuery = "UPDATE `civicrm_contribution_recur` SET `amount` = `amount` + %1 WHERE id = {$this->recurContributionId}";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
 }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -514,6 +514,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
 
     $sqlQuery = "UPDATE `civicrm_contribution` SET {$amountFieldOperation} WHERE id = {$this->contributionId}";
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
+
+    $trxSqlParams[1] = [$totalAmount, 'Money'];
+    $sqlQuery = "UPDATE `civicrm_entity_financial_trxn` ceft 
+                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id      
+                 SET ceft.amount = ceft.amount + %1, cft.total_amount = cft.total_amount + %1
+                 WHERE ceft.entity_table = 'civicrm_contribution' AND ceft.entity_id = {$this->contributionId}";
+    SQLQueryRunner::executeQuery($sqlQuery, $trxSqlParams);
   }
 
   /**

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
+
 class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
   private $rowData;
@@ -42,22 +44,22 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
     $sqlQuery = "INSERT INTO `civicrm_membership` (`contact_id` , `membership_type_id`, `join_date`, `start_date`, `end_date`, `status_id`,
                  `is_pay_later`, `contribution_recur_id`, `is_override`, `status_override_end_date`) 
             VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as membership_id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as membership_id');
     $dao->fetch();
     $membershipId = $dao->membership_id;
 
     $sqlQuery = "INSERT INTO `civicrm_value_membership_ext_id` (`entity_id` , `external_id`) 
            VALUES ({$membershipId}, %1)";
-    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
+    SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
 
     return $membershipId;
   }
 
   private function getMembershipIdIfExist() {
     $sqlQuery = "SELECT entity_id as id FROM civicrm_value_membership_ext_id WHERE external_id = %1";
-    $membershipId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
+    $membershipId = SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['membership_external_id'], 'String']]);
     $membershipId->fetch();
 
     if (!empty($membershipId->id)) {
@@ -98,7 +100,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
     if (!isset($this->cachedValues['membership_types'])) {
       $sqlQuery = "SELECT id, name FROM civicrm_membership_type";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['membership_types'][$result->name] = $result->id;
       }
@@ -127,7 +129,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
     if (!isset($this->cachedValues['membership_statuses'])) {
       $sqlQuery = "SELECT id, name FROM civicrm_membership_status";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['membership_statuses'][$result->name] = $result->id;
       }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
+
 /**
  * Imports the recurring contribution record.
  *
@@ -31,9 +33,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
             `start_date`, `contribution_status_id`, `payment_processor_id` , `financial_type_id` , `payment_instrument_id`, `auto_renew`, `create_date`,
             `next_sched_contribution_date`, `cycle_day`) 
             VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9 ,%10, %11, %12, %13, %14, %15)";
-    CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
-    $dao = CRM_Core_DAO::executeQuery('SELECT LAST_INSERT_ID() as recur_contribution_id');
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as recur_contribution_id');
     $dao->fetch();
     $recurContributionId = $dao->recur_contribution_id;
 
@@ -41,14 +43,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
 
     $sqlQuery = "INSERT INTO `civicrm_value_contribution_recur_ext_id` (`entity_id` , `external_id`) 
            VALUES ({$recurContributionId}, %1)";
-    CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
+    SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
 
     return $recurContributionId;
   }
 
   private function getRecurContributionIdIfExist() {
     $sqlQuery = "SELECT entity_id as id FROM civicrm_value_contribution_recur_ext_id WHERE external_id = %1";
-    $recurContributionId = CRM_Core_DAO::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
+    $recurContributionId = SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['payment_plan_external_id'], 'String']]);
     $recurContributionId->fetch();
 
     if (!empty($recurContributionId->id)) {
@@ -126,7 +128,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
       $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
                   INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
                   WHERE cog.name = 'currencies_enabled'";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['currencies_enabled'][$result->name] = $result->id;
       }
@@ -170,7 +172,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
       $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
                   INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
                   WHERE cog.name = 'contribution_recur_status'";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['recur_contribution_statuses'][$result->name] = $result->id;
       }
@@ -198,7 +200,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   private function getPaymentProcessorId() {
     if (!isset($this->cachedValues['payment_processors'])) {
       $sqlQuery = "SELECT id, name, class_name FROM civicrm_payment_processor WHERE is_test = 0 AND is_active = 1";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['payment_processors'][$result->name] = ['id' => $result->id, 'class_name' => $result->class_name];
       }
@@ -220,7 +222,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   private function getFinancialTypeId() {
     if (!isset($this->cachedValues['financial_types'])) {
       $sqlQuery = "SELECT id, name FROM civicrm_financial_type";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['financial_types'][$result->name] = $result->id;
       }
@@ -238,7 +240,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
       $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
                   INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
                   WHERE cog.name = 'payment_instrument'";
-      $result = CRM_Core_DAO::executeQuery($sqlQuery);
+      $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {
         $this->cachedValues['payment_methods'][$result->name] = $result->id;
       }
@@ -304,7 +306,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
       (entity_id, is_active) VALUES ({$recurContributionId}, {$isActive}) 
       ON DUPLICATE KEY UPDATE is_active = {$isActive} 
      ";
-    CRM_Core_DAO::executeQuery($activationQuery);
+    SQLQueryRunner::executeQuery($activationQuery);
   }
 
 }

--- a/CRM/Membershipextrasimporterapi/Helper/SQLQueryRunner.php
+++ b/CRM/Membershipextrasimporterapi/Helper/SQLQueryRunner.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner {
+
+  /**
+   * Executes the given SQL query with the
+   * given data parameters.
+   *
+   * This is just a wrapper for the core
+   * CRM_Core_DAO::executeQuery() method but with
+   * more detailed error message, since the
+   * normal error message thrown by the Core
+   * especially when validating the data parameters are
+   * not usually helpful.
+   *
+   * @param string $sqlQuery
+   * @param array $sqlParams
+   *
+   * @return CRM_Core_DAO
+   *
+   * @throws CRM_Core_Exception
+   */
+  public static function executeQuery($sqlQuery, $sqlParams = []) {
+    try {
+      return CRM_Core_DAO::executeQuery($sqlQuery, $sqlParams);
+    }
+    catch (Exception $exception) {
+      $errorMessage = $exception->getMessage();
+      $errorMessage .= " | Failed executing the following SQL Query: '$sqlQuery'.";
+      $errorMessage .= ' - With the following data: ' . print_r($sqlParams, TRUE);
+      throw new CRM_Core_Exception($errorMessage);
+    }
+  }
+
+}


### PR DESCRIPTION
This PR includes the following fixes and improvements : 


1- Here https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/12/commits/6070e79f19351de2bd6725ea8951ff52fc0a8dd2 I am improving the error messages thrown by the importer SQL query, the usual error messages thrown by CiviCRM specially when validating the SQL query data parameters are not usually helpful, so I am here just adding more context and info to these errors to help identifying any problem that might occur.

2- Here https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/12/commits/ca652b5b64fdf3e0d462e396182e8fc7626a9595 I am enclosing the whole import process for any single row in a MySQL transaction, to ensure data integrity if something goes wrong.

3- And here https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/12/commits/72a5e631eceedd33f2d92f14208fde8b1e39f5b6
I am fixing a bug where the contribution financial transaction and entity finical transactions amounts are set to 0 (zero), instead of being updated to match the related contribution amount.
