### PR TITLE
MAE-509: Updating certain entities if they already exist 

### DIFF
--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -63,7 +63,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
   private function updateExistingMembership($membershipId) {
     $sqlParams = $this->prepareSqlParams();
-    $sqlParams[11] =  [$membershipId, 'Integer'];
+    $sqlParams[11] = [$membershipId, 'Integer'];
     $sqlQuery = "UPDATE `civicrm_membership` SET 
                 `contact_id` = %1, `membership_type_id` = %2, `join_date` = %3, `start_date` = %4, `end_date` = %5, 
                 `status_id` = %6, `is_pay_later` = %7, `contribution_recur_id` = %8, `is_override` = %9, 

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -21,13 +21,34 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
   }
 
   public function import() {
-    $recurContributionId = $this->getRecurContributionIdIfExist();
-    if ($recurContributionId) {
-      return $recurContributionId;
-    }
-
     $this->validateIfDirectDebitPaymentPlan();
 
+    $recurContributionId = $this->getRecurContributionIdIfExist();
+    if ($recurContributionId) {
+      $this->updateExistingRecurContribution($recurContributionId);
+    }
+    else {
+      $recurContributionId = $this->createNewRecurContribution();
+    }
+
+    $this->setActiveStatus($recurContributionId);
+
+    return $recurContributionId;
+  }
+
+  private function updateExistingRecurContribution($recurContributionId) {
+    $sqlParams = $this->prepareSqlParams();
+    $sqlParams[16] =  [$recurContributionId, 'Integer'];
+    $sqlQuery = "UPDATE `civicrm_contribution_recur` SET 
+                `contact_id` = %1, `amount` = %2, `currency` = %3, `frequency_unit` = %4, `frequency_interval` = %5, 
+                `installments` = %6, `start_date` = %7, `contribution_status_id` = %8, `payment_processor_id` = %9, 
+                `financial_type_id` = %10, `payment_instrument_id` = %11, `auto_renew` = %12, `create_date` = %13,
+                `next_sched_contribution_date` = %14, `cycle_day` = %15
+                WHERE id = %16";
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
+  }
+
+  private function createNewRecurContribution() {
     $sqlParams = $this->prepareSqlParams();
     $sqlQuery = "INSERT INTO `civicrm_contribution_recur` (`contact_id` , `amount` , `currency` , `frequency_unit` , `frequency_interval` , `installments` ,
             `start_date`, `contribution_status_id`, `payment_processor_id` , `financial_type_id` , `payment_instrument_id`, `auto_renew`, `create_date`,
@@ -38,8 +59,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
     $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as recur_contribution_id');
     $dao->fetch();
     $recurContributionId = $dao->recur_contribution_id;
-
-    $this->setActiveStatus($recurContributionId);
 
     $sqlQuery = "INSERT INTO `civicrm_value_contribution_recur_ext_id` (`entity_id` , `external_id`) 
            VALUES ({$recurContributionId}, %1)";

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -38,7 +38,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
 
   private function updateExistingRecurContribution($recurContributionId) {
     $sqlParams = $this->prepareSqlParams();
-    $sqlParams[16] =  [$recurContributionId, 'Integer'];
+    $sqlParams[16] = [$recurContributionId, 'Integer'];
     $sqlQuery = "UPDATE `civicrm_contribution_recur` SET 
                 `contact_id` = %1, `amount` = %2, `currency` = %3, `frequency_unit` = %4, `frequency_interval` = %5, 
                 `installments` = %6, `start_date` = %7, `contribution_status_id` = %8, `payment_processor_id` = %9, 

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/DirectDebitMandateTest.php
@@ -358,7 +358,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
       'account_number' => '87654321',
       'sort_code' => '654321',
       'mandate_code' => 1,
-      'start_date' => '2022-01-01 00:00:00'
+      'start_date' => '2022-01-01 00:00:00',
     ];
 
     $updatedMandate = $this->getMandateById($firstMandateId);

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -340,7 +340,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
 
     $expectedResult = [
       'membership_type' => $this->getMembershipTypeId('General'),
-      'join_date' =>  '2019-01-01',
+      'join_date' => '2019-01-01',
       'start_date' => '2020-01-01',
       'end_date' => '2020-12-31',
       'status' => $this->getMembershipStatusId('Pending'),
@@ -351,7 +351,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
     $actualResult = [
       'membership_type' => $updatedMembership['membership_type_id'],
       'join_date' => $updatedMembership['join_date'],
-      'start_date' =>  $updatedMembership['start_date'],
+      'start_date' => $updatedMembership['start_date'],
       'end_date' => $updatedMembership['end_date'],
       'status' => $updatedMembership['status_id'],
       'is_status_overridden' => $updatedMembership['is_override'],

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/MembershipTest.php
@@ -53,7 +53,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_MembershipTest extends Base
   }
 
   public function testImportExistingMembershipWillNotCreateNewOne() {
-    $this->sampleRowData['payment_plan_external_id'] = 'test2';
+    $this->sampleRowData['membership_external_id'] = 'test2';
 
     $firstImport = new MembershipImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $firstMembershipId = $firstImport->import();

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -560,7 +560,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
     $expectedResult = [
       'total_amount' => '100.00',
-      'frequency_unit' =>  'year',
+      'frequency_unit' => 'year',
       'frequency_interval' => 1,
       'installments' => 1,
       'next_contribution_date' => '2022-01-01 00:00:00',


### PR DESCRIPTION
## Before
Currently, if any of these entities  :

1- Recurring Contribution
2- Membership
3- Direct debit Mandate


Is already created (the check happen using the external id), then the importer will skip processing the row for that entity.

The importer needs to ensure that these entities are getting updated with the most recent info in case they already exist.


## After
The mentioned entities data are getting updated if they already exist.
