### PR TITLE
MAE-520: Fix missing payments and some other missing data after import

### DIFF
--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -27,8 +27,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
     $sqlParams = $this->prepareSqlParams();
     $sqlQuery = "INSERT INTO `civicrm_contribution` (`contact_id` , `financial_type_id` , `payment_instrument_id` , 
                  `receive_date` , `total_amount` , `currency`, `contribution_recur_id` , `is_pay_later`,
-                  `contribution_status_id`, `invoice_number`) 
-                 VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10)";
+                  `contribution_status_id`, `invoice_number`, `source`) 
+                 VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11)";
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
     $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as contribution_id');
@@ -78,7 +78,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
       7 => [$this->recurContributionId, 'Integer'],
       8 => [$isPayLater, 'Integer'],
       9 => [$contributionStatusId, 'Integer'],
-      10 => [$invoiceNumber, 'String']
+      10 => [$invoiceNumber, 'String'],
+      11 => ['Membershipextras Importer at: ' . date('Y-m-d H:i'), 'String'],
     ];
   }
 

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -201,15 +201,24 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   private function createFinancialTransactionRecord($mappedContributionParams) {
+    $isPayment = 0;
+    if (!$mappedContributionParams['is_pay_later']) {
+      $isPayment = 1;
+    }
+
     $sqlParams = [
       1 => [$this->getToFinancialAccountId(), 'Integer'],
       2 => [$mappedContributionParams['total_amount'], 'Money'],
       3 => [$mappedContributionParams['currency'], 'String'],
       4 => [$mappedContributionParams['contribution_status_id'], 'Integer'],
       5 => [$mappedContributionParams['payment_method_id'], 'Integer'],
+      6 => [$mappedContributionParams['receive_date'], 'String'],
+      7 => [$mappedContributionParams['total_amount'], 'Money'],
+      8 => [$isPayment, 'Integer'],
     ];
-    $sqlQuery = "INSERT INTO `civicrm_financial_trxn` (`to_financial_account_id`, `total_amount` , `currency`, `status_id` , `payment_instrument_id`) 
-            VALUES (%1 , %2, %3, %4, %5)";
+    $sqlQuery = "INSERT INTO `civicrm_financial_trxn` (`to_financial_account_id`, `total_amount` , `currency`, `status_id` , `payment_instrument_id`,
+                `trxn_date`, `net_amount`, `is_payment`) 
+            VALUES (%1 , %2, %3, %4, %5, %6, %7, %8)";
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
     $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as id');
@@ -224,7 +233,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
    * for the import, we are using it to get to
    * get the financial account value.
    *
-   * @return id
+   * @return int
    */
   private function getToFinancialAccountId() {
     $paymentProcessorId = $this->getPaymentProcessorIdFromRecurContribution();

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -504,7 +504,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
   private function updateRelatedContributionAmounts($lineItemTotalAmount, $taxAmount) {
     $totalAmount = $lineItemTotalAmount + $taxAmount;
 
-    $amountFieldOperation = '`total_amount` = `total_amount` + %1';
+    $amountFieldOperation = '`total_amount` = `total_amount` + %1, `net_amount` = `net_amount` + %1';
     $sqlParams[1] = [$totalAmount, 'Money'];
 
     if (!empty($taxAmount)) {
@@ -517,8 +517,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
 
     $trxSqlParams[1] = [$totalAmount, 'Money'];
     $sqlQuery = "UPDATE `civicrm_entity_financial_trxn` ceft 
-                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id      
-                 SET ceft.amount = ceft.amount + %1, cft.total_amount = cft.total_amount + %1
+                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id 
+                 SET ceft.amount = ceft.amount + %1, cft.total_amount = cft.total_amount + %1, cft.net_amount = cft.net_amount + %1 
                  WHERE ceft.entity_table = 'civicrm_contribution' AND ceft.entity_id = {$this->contributionId}";
     SQLQueryRunner::executeQuery($sqlQuery, $trxSqlParams);
   }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -74,9 +74,10 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
 
   private function createNewMembership() {
     $sqlParams = $this->prepareSqlParams();
+    $sqlParams[11] = ['Membershipextras Importer at: ' . date('Y-m-d H:i') , 'String'];
     $sqlQuery = "INSERT INTO `civicrm_membership` (`contact_id` , `membership_type_id`, `join_date`, `start_date`, `end_date`, `status_id`,
-                 `is_pay_later`, `contribution_recur_id`, `is_override`, `status_override_end_date`) 
-            VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10)";
+                 `is_pay_later`, `contribution_recur_id`, `is_override`, `status_override_end_date`, `source`) 
+            VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11)";
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
 
     $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as membership_id');

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -178,6 +178,11 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'type' => CRM_Utils_Type::T_STRING,
   ];
 
+  $params['contribution_invoice_number'] = [
+    'title' => 'Contribution Invoice Number',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
   // Line Item
   $params['line_item_entity_table'] = [
     'title' => 'Order Line Entity Type',

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
@@ -224,25 +224,46 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends Ba
   }
 
   public function testImportWillCreateCorrectFinancialTransactionRecords() {
-    $this->sampleRowData['membership_external_id'] = 'test16';
+    $this->sampleRowData['contribution_external_id'] = 'test16';
 
     $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $newContributionId = $contributionImporter->import();
     $newContribution = $this->getContributionById($newContributionId);
 
-    $sqlQuery = "SELECT ceft.amount as ef_amount, cft.total_amount as f_amount, cft.currency, cft.status_id, cft.payment_instrument_id, cft.to_financial_account_id  
-                 FROM civicrm_entity_financial_trxn ceft
-                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id 
-                 WHERE ceft.entity_table = 'civicrm_contribution' AND ceft.entity_id = {$newContributionId}";
-    $result = CRM_Core_DAO::executeQuery($sqlQuery);
-    $result->fetch();
+    $contributionFinancialTrxn = $this->getContributionFinancialTransaction($newContributionId);
 
-    $this->assertEquals($newContribution['total_amount'], $result->ef_amount);
-    $this->assertEquals($newContribution['total_amount'], $result->f_amount);
-    $this->assertEquals($newContribution['currency'], $result->currency);
-    $this->assertEquals($newContribution['contribution_status_id'], $result->status_id);
-    $this->assertEquals($newContribution['payment_instrument_id'], $result->payment_instrument_id);
-    $this->assertEquals($this->getPaymentProcessorFinancialAccountId($this->testPaymentProcessorId), $result->to_financial_account_id);
+    $this->assertEquals($newContribution['total_amount'], $contributionFinancialTrxn->ef_amount);
+    $this->assertEquals($newContribution['total_amount'], $contributionFinancialTrxn->f_amount);
+    $this->assertEquals($newContribution['total_amount'], $contributionFinancialTrxn->f_net_amount);
+    $this->assertEquals($newContribution['receive_date'], $contributionFinancialTrxn->f_trxn_date);
+    $this->assertEquals($newContribution['currency'], $contributionFinancialTrxn->currency);
+    $this->assertEquals($newContribution['contribution_status_id'], $contributionFinancialTrxn->status_id);
+    $this->assertEquals($newContribution['payment_instrument_id'], $contributionFinancialTrxn->payment_instrument_id);
+    $this->assertEquals($this->getPaymentProcessorFinancialAccountId($this->testPaymentProcessorId), $contributionFinancialTrxn->to_financial_account_id);
+  }
+
+  public function testImportPendingContributionWillCreateUnpaidTransaction() {
+    $this->sampleRowData['contribution_external_id'] = 'test20';
+    $this->sampleRowData['contribution_status'] = 'Pending';
+    
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $contributionFinancialTrxn = $this->getContributionFinancialTransaction($newContributionId);
+
+    $this->assertEquals(0, $contributionFinancialTrxn->f_is_payment);
+  }
+
+  public function testImportCompletedContributionWillCreatePaidTransaction() {
+    $this->sampleRowData['contribution_external_id'] = 'test21';
+    $this->sampleRowData['contribution_status'] = 'Completed';
+
+    $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
+    $newContributionId = $contributionImporter->import();
+
+    $contributionFinancialTrxn = $this->getContributionFinancialTransaction($newContributionId);
+
+    $this->assertEquals(1, $contributionFinancialTrxn->f_is_payment);
   }
 
   public function testImportWithInvalidCurrencyThrowAnException() {
@@ -330,6 +351,18 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends Ba
     $result = CRM_Core_DAO::executeQuery($sqlQuery);
     $result->fetch();
     return $result->financial_account_id;
+  }
+
+  private function getContributionFinancialTransaction($contributionId) {
+    $sqlQuery = "SELECT ceft.amount as ef_amount, cft.total_amount as f_amount, cft.currency, cft.status_id, cft.payment_instrument_id, cft.to_financial_account_id,
+                 cft.trxn_date as f_trxn_date, cft.net_amount as f_net_amount, cft.is_payment as f_is_payment  
+                 FROM civicrm_entity_financial_trxn ceft
+                 INNER JOIN civicrm_financial_trxn cft ON ceft.financial_trxn_id = cft.id 
+                 WHERE ceft.entity_table = 'civicrm_contribution' AND ceft.entity_id = {$contributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+
+    return $result;
   }
 
 }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/LineItemTest.php
@@ -322,6 +322,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
     $contribution = $this->getContributionById($this->contributionId);
 
     $this->assertEquals(80.5, $contribution['total_amount']);
+    $this->assertEquals(80.5, $contribution['net_amount']);
   }
 
   public function testImportWillUpdateContributionRelatedFinancialRecordsAmountsToBeSameAsTheContribution() {
@@ -342,6 +343,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
 
     $this->assertEquals(80.5, $entityFinancialTrxn['amount']);
     $this->assertEquals(80.5, $financialTrxn['total_amount']);
+    $this->assertEquals(80.5, $financialTrxn['net_amount']);
   }
 
   public function testImportWithTaxWillUpdateContributionAmountToTheSumOfLineItemsAmountsAndTaxes() {
@@ -364,6 +366,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
     $contribution = $this->getContributionById($this->contributionId);
 
     $this->assertEquals(95.83, $contribution['total_amount']);
+    $this->assertEquals(95.83, $contribution['net_amount']);
   }
 
   public function testImportWithTaxWillUpdateContributionRelatedFinancialRecordsAmountsToBeSameAsTheContribution() {
@@ -388,6 +391,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItemTest extends BaseHe
 
     $this->assertEquals(95.83, $entityFinancialTrxn['amount']);
     $this->assertEquals(95.83, $financialTrxn['total_amount']);
+    $this->assertEquals(95.83, $financialTrxn['net_amount']);
   }
 
   public function testImportWithTaxWillUpdateContributionTaxAmountToTheSumOfLineItemsTaxAmounts() {


### PR DESCRIPTION
In this PR: 

1- 

Importing Completed contribution does not show the payment information : 
![2021-03-26 22_04_42-dasdsa dsadsa _ compuvag5one](https://user-images.githubusercontent.com/6275540/112681143-32802780-8e66-11eb-8326-3adfa0dac768.png)

Which is fixed by following the same way CiviCRM handles that, by updating the value of contribution financial transaction is_payment field (civicrm_financial_trxn.is_payment) to 0 if the contribution status is Pending or In Progress, or 1 otherwise.

![2021-03-26 22_04_54-dsadas dsadsa _ compuvag5one](https://user-images.githubusercontent.com/6275540/112681152-357b1800-8e66-11eb-9f3f-79c9acb0316e.png)

Also, the transaction date of the financial transaction is now getting updated to equal the contribution receive date (as in civic core).


2- Also a new mapping field is added to allow users to import the contribution invoice number (the field is called "Contribution Invoice Number"). If the invoice number is not set in the CSV file then this extension will check if CiviCRM invoicing is enabled and if thus it will try to calculate it similar to how CiviCRM core does that, if invoicing is disabled then the invoice number will remain empty.

3- I also updated the `net amount` for contribution to equal the `total amount`, usually the `net amount` = `total amount` - `fee amount`, but since we don't support `fee amount` yet , the two values should be the same.

4- And finally I did a little improvement where any membership or contribution is created by this importer will have its source field set to "Membershipextras Importer at: [Current Time]"