### PR TITLE
MAE-528: Bump version for 1.0.0 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.35.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.28.3
+          version: 5.35.1
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Membership.php
@@ -141,7 +141,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Membership {
         $this->rowData['membership_start_date'],
         $this->rowData['membership_end_date'],
         $this->rowData['membership_join_date'],
-        'today',
+        'now',
         TRUE,
         $membershipTypeId
       );

--- a/info.xml
+++ b/info.xml
@@ -2,17 +2,17 @@
 <extension key="uk.co.compucorp.membershipextrasimporterapi" type="module">
   <file>membershipextrasimporterapi</file>
   <name>Membershipextras Importer API</name>
-  <description>Payment plans importer API endpoint for Membershipextras, to be used with nz.co.fuzion.csvimport extension</description>
+  <description>Payment plans importer API endpoint for Membershipextras, to be used with nz.co.fuzion.csvimport and Membershipextras extensions</description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Compucorp Ltd.</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2021-03-04</releaseDate>
-  <version>1.0.0-alpha</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2021-04-19</releaseDate>
+  <version>1.0.0</version>
+  <develStage>stable</develStage>
   <compatibility>
-    <ver>5.28</ver>
+    <ver>5.35</ver>
   </compatibility>
   <requires>
     <ext>uk.co.compucorp.membershipextras</ext>
@@ -20,7 +20,7 @@
   </requires>
   <comments>
     Supported CiviCRM versions  :
-    - 5.28.3
+    - 5.35.1
   </comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>


### PR DESCRIPTION
Here I tag the first stable version 1.0.0 after we tested this with real client data and things look fine. As part of this, I also updated the test workflow to use the same drupal and civic version as Compuclient 1.20, which resulted in one failed test related to a small deprecation issue that I fixed here : 

https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/15/commits/7ee19f658a9bacbc5ee0d830423192ba72167c2e