### PR TITLE
MAE-529: Fix errors count in case of failure 

### DIFF
--- a/CRM/Membershipextrasimporterapi/Helper/SQLQueryRunner.php
+++ b/CRM/Membershipextrasimporterapi/Helper/SQLQueryRunner.php
@@ -28,6 +28,7 @@ class CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner {
       $errorMessage = $exception->getMessage();
       $errorMessage .= " | Failed executing the following SQL Query: '$sqlQuery'.";
       $errorMessage .= ' - With the following data: ' . print_r($sqlParams, TRUE);
+      $errorMessage = str_replace("\n", ' ', $errorMessage);
       throw new CRM_Core_Exception($errorMessage);
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,20 +1,58 @@
 # Membershipextras Importer API
 
-This extension creates new API Endpoint `MembershipextrasImporter`, that can be used within [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension,
-and allows importing Payment Plan membership orders and direct debit information for the use of Membershipextras suite.
+This extension creates new API Endpoint `MembershipextrasImporter` that can be used within [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension,
+which allows importing Payment Plan membership orders and direct debit information using the data model used in [Membershipextras](https://github.com/compucorp/uk.co.compucorp.membershipextras) suite.
+
+More details about the functionality of this importer and fields mapping are available here (not publicly available document yet): 
+https://compucorp.atlassian.net/wiki/spaces/ME/pages/2307489795/Membership+importer+Ready+for+kickoff+Payment+plan+importer
 
 # Dependencies
 To be able to use this extension you will need : 
 
-- [Membershipextras extension](https://github.com/compucorp/uk.co.compucorp.membershipextras) : Which provides support for payment plan memberships
-- [CSV Importer extension](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) : Which provides the mechanism to import CSV files using any API Endpoint
+- [Membershipextras extension](https://github.com/compucorp/uk.co.compucorp.membershipextras) : Which provides support for payment plan memberships.
+- [CSV Importer extension](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) : Which provides the mechanism to import CSV files using any API Endpoint.
 
 And optionally : 
 - [Manual Direct debit extension](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit) : In case you have payment plan orders paid with Direct debit.
 
 
-It also requires the following custom groups and their custom fields to be activated : 
+It also requires the following custom groups (which are created by Membershipextras extension and disabled by default) and their custom fields to be activated : 
 
 - Recurring Contribution External ID
 - Contribution External ID
 - Membership External ID
+
+## Usage
+
+As mentioned above, this extension is to be used within  [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension, by going
+to the extension import screen and selecting `MembershipextrasImporter` in "Entity To Import" select list:
+
+![1](https://user-images.githubusercontent.com/6275540/115318172-e0d96d00-a185-11eb-9350-704a0f2370c6.png)
+
+Then choose the CSV file you want to import and go through the rest of the steps. Though, hence the following:
+
+1- Once the import begins, it will process rows in batches and it will trigger separate Ajax request for each batch, the number of rows to be processed
+in each batch are controlled by "Number Of Items To Process For Each Queue Item" setting : 
+
+![2](https://user-images.githubusercontent.com/6275540/115318178-e3d45d80-a185-11eb-909e-5e8a425dbdd8.png)
+
+You need to choose a number that is not very large which might result in timeout issues, nor a number that is very small that result in a lot of Ajax
+requests to the server. For example, suppose you have 100,000 records to import and suppose that your PHP timeout setting is 60 seconds, if you select 
+the number of items to process setting to be 1, then the importer will trigger 100,000 ajax request to the server which is a lot, and if you choose a number
+such as 10,000, then the importer will most likely take more than 60 seconds to process such number of rows in a single Ajax request, so try to find a number
+that works best for your server configurations.
+
+2- Both "Allow Updating An Entity Using Unique Fields" and "Ignore Case For Field Option Values" do not work currently, and enabling them will prevent the importer
+from running and might cause issues. So just keep them disabled. Although hence that `MembershipextrasImporter` API will by default try
+to update existing records, also hence that it by default looks for existing records using the supplied external id for each entity.
+
+![3](https://user-images.githubusercontent.com/6275540/115318186-eb940200-a185-11eb-89a3-8766f4125e70.png)
+
+3- Depending on your server configurations and the size of the data you are trying to import,you might need to consider increasing 
+the following configurations:
+
+A- Nginx `client_max_body_size`.
+B- PHP `upload_max_filesize` and `post_max_size`.
+C- CiviCRM `Maximum File Size` which is available at `/civicrm/admin/setting/misc?reset=1` and should match PHP `upload_max_filesize`.
+
+also consider splitting large files into smaller ones and import them one by one.


### PR DESCRIPTION
## Before
If the error thrown by the importer contains new lines, then each new line will be counted as a separate error in the importer summary page even though it is technically a single error.

This replaces the new lines with spaces in the resulted error message so the correct number of errors appear.

![2021-04-20 03_28_40-API Import _ compuvag6one](https://user-images.githubusercontent.com/6275540/115319497-a02f2300-a188-11eb-8091-3b8365cf4a4a.png)

![2021-04-20 03_29_13-Microsoft Excel - Import_Errors (7)](https://user-images.githubusercontent.com/6275540/115319513-a6250400-a188-11eb-8f62-e5d2bd6a0641.png)


## After

![2021-04-20 03_26_39-API Import _ compuvag6one](https://user-images.githubusercontent.com/6275540/115319390-652cef80-a188-11eb-97e7-e7686a9072de.png)

![2021-04-20 03_27_01-Movies   TV](https://user-images.githubusercontent.com/6275540/115319394-678f4980-a188-11eb-864c-0a5d1c921cd7.png)


I also updated the readme file to contain more detailed information about this extension.



