### PR TITLE
BASW-788: Fix membership payment record creation

### DIFF
--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -31,7 +31,7 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
       $contributionImporter = new ContributionImporter($this->rowData, $this->contactId, $recurContributionId);
       $contributionId = $contributionImporter->import();
 
-      if ($membershipId == NULL) {
+      if ($membershipId != NULL) {
         $membershipPaymentCreator = new MembershipPaymentCreator($membershipId, $contributionId);
         $membershipPaymentCreator->create();
       }


### PR DESCRIPTION
## Overview

I discovered that Membership Payment (civicrm_membership_payment) records were not getting  created because a wrong if condition, this PR fixes that.