### PR TITLE
MAE-636: Move External Id custom groups and fields from Membershipextras to this extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 7
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.0.0
+    container: compucorp/civicrm-buildkit:1.1.1-php7.2
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Installing Membershipextras Importer API extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git -b MAE-636-reorgnise-upgrader
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
           git clone --depth 1 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi

--- a/CRM/Membershipextrasimporterapi/Upgrader.php
+++ b/CRM/Membershipextrasimporterapi/Upgrader.php
@@ -1,8 +1,100 @@
 <?php
 
+use CRM_Membershipextrasimporterapi_ExtensionUtil as ExtensionUtil;
+
 /**
  * Collection of upgrade steps.
  */
 class CRM_Membershipextrasimporterapi_Upgrader extends CRM_Membershipextrasimporterapi_Upgrader_Base {
+
+  public function postInstall() {
+    $this->setupLineItemExternalId();
+    $this->setExternalIdFieldsToBeUnique();
+  }
+
+  /**
+   * Creates the Line item external id which might be useful for data import at some point
+   * later (though we have no use for it currently).
+   * we create it in code instead of using XML because LineItem entity does not support
+   * custom groups by default, and thus we have to add it to `cg_extend_objects` option
+   * group first.
+   */
+  private function setupLineItemExternalId() {
+    $this->makeLineItemEntityAnExtendableEntity();
+    $this->createLineItemExternalIDCustomGroupAndField();
+  }
+
+  /**
+   * Adds unique constraint on all external ids custom group tables.
+   */
+  private function setExternalIdFieldsToBeUnique() {
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN,
+      ExtensionUtil::path() . DIRECTORY_SEPARATOR . 'sql/set_unique_external_ids.sql'
+    );
+  }
+
+  /**
+   * Adds the line item entity as an option value
+   * to cg_extend_objects option group, which is
+   * a CiviCRM core custom group. Option values
+   * added to this Option group allows CiviCRM core
+   * to support creating custom groups on entities
+   * that does not support custom groups by default
+   * such as the Line item entity.
+   * See: https://docs.civicrm.org/dev/en/latest/step-by-step/create-entity/#111-making-our-entity-available-for-custom-data
+   */
+  private function makeLineItemEntityAnExtendableEntity() {
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_line_item',
+    ]);
+
+    if (!$optionValues['count']) {
+      civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => 'cg_extend_objects',
+        'name' => 'civicrm_line_item',
+        'label' => ts('Line Item'),
+        'value' => 'LineItem',
+      ]);
+    }
+  }
+
+  private function createLineItemExternalIDCustomGroupAndField() {
+    $customGroup = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'LineItem',
+      'name' => 'line_item_external_id',
+    ]);
+    if (!$customGroup['count']) {
+      $customGroup = civicrm_api3('CustomGroup', 'create', [
+        'extends' => 'LineItem',
+        'name' => 'line_item_external_id',
+        'title' => ts('Line Item External ID'),
+        'table_name' => 'civicrm_value_line_item_ext_id',
+        'is_active' => 1,
+        'style' => 'Inline',
+        'is_multiple' => 0,
+      ]);
+    }
+
+    $customField = civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => $customGroup['id'],
+      'name' => 'external_id',
+    ]);
+    if (!$customField['count']) {
+      civicrm_api3('CustomField', 'create', [
+        'custom_group_id' => $customGroup['id'],
+        'name' => 'external_id',
+        'label' => ts('External ID'),
+        'data_type' => 'String',
+        'html_type' => 'Text',
+        'required' => 0,
+        'is_active' => 1,
+        'is_searchable' => 1,
+        'column_name' => 'external_id',
+        'is_view' => 1,
+      ]);
+    }
+  }
 
 }

--- a/CRM/Membershipextrasimporterapi/Upgrader.php
+++ b/CRM/Membershipextrasimporterapi/Upgrader.php
@@ -12,6 +12,10 @@ class CRM_Membershipextrasimporterapi_Upgrader extends CRM_Membershipextrasimpor
     $this->setExternalIdFieldsToBeUnique();
   }
 
+  public function uninstall() {
+    $this->removeExternalIdCustomGroupsAndFields();
+  }
+
   /**
    * Creates the Line item external id which might be useful for data import at some point
    * later (though we have no use for it currently).
@@ -93,6 +97,27 @@ class CRM_Membershipextrasimporterapi_Upgrader extends CRM_Membershipextrasimpor
         'is_searchable' => 1,
         'column_name' => 'external_id',
         'is_view' => 1,
+      ]);
+    }
+  }
+
+  private function removeExternalIdCustomGroupsAndFields() {
+    $customGroups = [
+      'recurring_contribution_external_id',
+      'contribution_external_id',
+      'membership_external_id',
+      'line_item_external_id',
+    ];
+    foreach ($customGroups as $customGroupName) {
+      civicrm_api3('CustomField', 'get', [
+        'name' => 'external_id',
+        'custom_group_id' => $customGroupName,
+        'api.CustomField.delete' => ['id' => '$value.id'],
+      ]);
+
+      civicrm_api3('CustomGroup', 'get', [
+        'name' => $customGroupName,
+        'api.CustomGroup.delete' => ['id' => '$value.id'],
       ]);
     }
   }

--- a/README.md
+++ b/README.md
@@ -3,24 +3,17 @@
 This extension creates new API Endpoint `MembershipextrasImporter` that can be used within [CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension,
 which allows importing Payment Plan membership orders and direct debit information using the data model used in [Membershipextras](https://github.com/compucorp/uk.co.compucorp.membershipextras) suite.
 
-More details about the functionality of this importer and fields mapping are available here (not publicly available document yet): 
+More details about the functionality of this importer and fields mapping are available here (not publicly available document yet):
 https://compucorp.atlassian.net/wiki/spaces/ME/pages/2307489795/Membership+importer+Ready+for+kickoff+Payment+plan+importer
 
 # Dependencies
-To be able to use this extension you will need : 
+To be able to use this extension you will need :
 
 - [Membershipextras extension](https://github.com/compucorp/uk.co.compucorp.membershipextras) : Which provides support for payment plan memberships.
 - [CSV Importer extension](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) : Which provides the mechanism to import CSV files using any API Endpoint.
 
-And optionally : 
+And optionally :
 - [Manual Direct debit extension](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit) : In case you have payment plan orders paid with Direct debit.
-
-
-It also requires the following custom groups (which are created by Membershipextras extension and disabled by default) and their custom fields to be activated : 
-
-- Recurring Contribution External ID
-- Contribution External ID
-- Membership External ID
 
 ## Usage
 
@@ -32,12 +25,12 @@ to the extension import screen and selecting `MembershipextrasImporter` in "Enti
 Then choose the CSV file you want to import and go through the rest of the steps. Though, hence the following:
 
 1- Once the import begins, it will process rows in batches and it will trigger separate Ajax request for each batch, the number of rows to be processed
-in each batch are controlled by "Number Of Items To Process For Each Queue Item" setting : 
+in each batch are controlled by "Number Of Items To Process For Each Queue Item" setting :
 
 ![2](https://user-images.githubusercontent.com/6275540/115318178-e3d45d80-a185-11eb-909e-5e8a425dbdd8.png)
 
 You need to choose a number that is not very large which might result in timeout issues, nor a number that is very small that result in a lot of Ajax
-requests to the server. For example, suppose you have 100,000 records to import and suppose that your PHP timeout setting is 60 seconds, if you select 
+requests to the server. For example, suppose you have 100,000 records to import and suppose that your PHP timeout setting is 60 seconds, if you select
 the number of items to process setting to be 1, then the importer will trigger 100,000 ajax request to the server which is a lot, and if you choose a number
 such as 10,000, then the importer will most likely take more than 60 seconds to process such number of rows in a single Ajax request, so try to find a number
 that works best for your server configurations.
@@ -48,7 +41,7 @@ to update existing records, also hence that it by default looks for existing rec
 
 ![3](https://user-images.githubusercontent.com/6275540/115318186-eb940200-a185-11eb-89a3-8766f4125e70.png)
 
-3- Depending on your server configurations and the size of the data you are trying to import,you might need to consider increasing 
+3- Depending on your server configurations and the size of the data you are trying to import,you might need to consider increasing
 the following configurations:
 
 A- Nginx `client_max_body_size`.

--- a/sql/set_unique_external_ids.sql
+++ b/sql/set_unique_external_ids.sql
@@ -1,0 +1,10 @@
+-- /*******************************************************
+-- * Set External IDs as unique fields
+-- *******************************************************/
+ALTER TABLE civicrm_value_contribution_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_contribution_recur_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_membership_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_line_item_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+
+
+

--- a/xml/customGroups_install.xml
+++ b/xml/customGroups_install.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<CustomData>
+    <CustomGroups>
+        <CustomGroup>
+            <name>recurring_contribution_external_id</name>
+            <title>Recurring Contribution External ID</title>
+            <extends>ContributionRecur</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_contribution_recur_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
+        <CustomGroup>
+            <name>contribution_external_id</name>
+            <title>Contribution External ID</title>
+            <extends>Contribution</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_contribution_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
+        <CustomGroup>
+            <name>membership_external_id</name>
+            <title>Membership External ID</title>
+            <extends>Membership</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_membership_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
+    </CustomGroups>
+    <CustomFields>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>recurring_contribution_external_id</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>contribution_external_id</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>membership_external_id</custom_group_name>
+        </CustomField>
+    </CustomFields>
+</CustomData>


### PR DESCRIPTION
## Overview

Here I moved the External ID custom field/group on Recur Contributions, Contributions, Memberships and Line items from Membershipextras extension to this one, given that these custom fields/groups are only created for the importer use, so it make more sense to have them here.