### PR TITLE
MAE-889: Update testing workflow to PHP 8 container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Installing Membershipextras Importer API extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
-          git clone --depth 1 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
+          git clone --depth 1 -b MAE-807-PHP8 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 -b MAE-807-php8-update https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
+          git clone --depth 1 -b 1.10 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
 
       - name: Run phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 7
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -31,14 +31,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.39.1
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Overview
Updating the unit-tests container, CiviCRM, Drupal and other dependencies to the PHP8 version.