### PR TITLE
CIVIIB-54: Use Master branch for tests workflow dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Installing Membershipextras Importer API extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 -b MAE-807-PHP8 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
-          git clone --depth 1 -b MAE-807-php8-update https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
           git clone --depth 1 -b 1.10 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
 


### PR DESCRIPTION
## Overview

Since the PHP 8 branch for both Membershipextras and Manualdirectdebit and now merged to `Master`, I've updated the tests workflow to use the Master branch of these extensions instead of the deleted PHP 8 branch.
