### PR TITLE
CIWEMB-84: Adding support for the entities and fields added as part of CIWEM work

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 7
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Installing Membershipextras Importer API extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1  -b CIWEMB-84-workstream https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.multicompanyaccounting.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.automateddirectdebit.git
-          git clone --depth 1 -b 1.10 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
+          git clone --depth 1 -b 1.10-patches https://github.com/compucorp/nz.co.fuzion.csvimport.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit io.compuco.automateddirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
 
       - name: Run phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,9 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
+          git clone --depth 1 https://github.com/compucorp/io.compuco.automateddirectdebit.git
           git clone --depth 1 -b 1.10 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
-          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
+          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit io.compuco.automateddirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
 
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextrasimporterapi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Installing Membershipextras Importer API extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1  -b CIWEMB-84-workstream https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.multicompanyaccounting.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.automateddirectdebit.git

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
+          git clone --depth 1 https://github.com/compucorp/io.compuco.multicompanyaccounting.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.automateddirectdebit.git
           git clone --depth 1 -b 1.10 https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit io.compuco.automateddirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi

--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -5,7 +5,7 @@ use CRM_Membershipextrasimporterapi_EntityImporter_Membership as MembershipImpor
 use CRM_Membershipextrasimporterapi_EntityImporter_Contribution as ContributionImporter;
 use CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment as MembershipPaymentCreator;
 use CRM_Membershipextrasimporterapi_EntityImporter_LineItem as LineItemImporter;
-use CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate as DirectDebitMandateImporter;
+use CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandate as ManualDirectDebitMandateImporter;
 use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
 
 class CRM_Membershipextrasimporterapi_CSVRowImporter {
@@ -39,7 +39,7 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
       $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId, $recurContributionId);
       $lineItemImporter->import();
 
-      $mandateImporter = new DirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);
+      $mandateImporter = new ManualDirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);
       $mandateImporter->import();
 
       $transaction->commit();

--- a/CRM/Membershipextrasimporterapi/CSVRowImporter.php
+++ b/CRM/Membershipextrasimporterapi/CSVRowImporter.php
@@ -6,6 +6,7 @@ use CRM_Membershipextrasimporterapi_EntityImporter_Contribution as ContributionI
 use CRM_Membershipextrasimporterapi_EntityCreator_MembershipPayment as MembershipPaymentCreator;
 use CRM_Membershipextrasimporterapi_EntityImporter_LineItem as LineItemImporter;
 use CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandate as ManualDirectDebitMandateImporter;
+use CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate as ExternalDirectDebitMandateImporter;
 use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
 
 class CRM_Membershipextrasimporterapi_CSVRowImporter {
@@ -39,8 +40,11 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
       $lineItemImporter = new LineItemImporter($this->rowData, $contributionId, $membershipId, $recurContributionId);
       $lineItemImporter->import();
 
-      $mandateImporter = new ManualDirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);
-      $mandateImporter->import();
+      $manualMandateImporter = new ManualDirectDebitMandateImporter($this->rowData, $this->contactId, $recurContributionId, $contributionId);
+      $manualMandateImporter->import();
+
+      $externalMandateImporter = new ExternalDirectDebitMandateImporter($this->rowData, $recurContributionId);
+      $externalMandateImporter->import();
 
       $transaction->commit();
     }
@@ -52,8 +56,6 @@ class CRM_Membershipextrasimporterapi_CSVRowImporter {
   }
 
   private function getContactId() {
-    $contactId = NULL;
-
     if (!empty($this->rowData['contact_id'])) {
       $sqlQuery = "SELECT id FROM civicrm_contact WHERE id = %1";
       $result = SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['contact_id'], 'Integer']]);

--- a/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
@@ -43,7 +43,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate 
   private function getRecurContributionCurrentMandateRecordIdIfExist() {
     $sql = "SELECT id FROM civicrm_value_external_dd_mandate_information WHERE entity_id = %1";
     $dao = SQLQueryRunner::executeQuery($sql, [
-      1 => [$this->recurContributionId, 'Int'],
+      1 => [$this->recurContributionId, 'Integer'],
     ]);
 
     $dao->fetch();

--- a/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
@@ -1,0 +1,90 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
+
+class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate {
+
+  private $rowData;
+
+  private $recurContributionId;
+
+  public function __construct($rowData, $recurContributionId) {
+    $this->rowData = $rowData;
+    $this->recurContributionId = $recurContributionId;
+  }
+
+  public function import() {
+    if (!$this->isExternalMandateInformationAvailable()) {
+      return NULL;
+    }
+
+    $mandateRecordId = $this->getRecurContributionCurrentMandateRecordIdIfExist();
+    if ($mandateRecordId) {
+      $this->updateMandate($mandateRecordId);
+    }
+    else {
+      $mandateRecordId = $this->createMandate();
+    }
+
+    return $mandateRecordId;
+  }
+
+  private function isExternalMandateInformationAvailable() {
+    $externalMandateFields = ['external_direct_debit_mandate_id', 'external_direct_debit_next_available_payment_date'];
+    foreach ($externalMandateFields as $externalMandateFieldName) {
+      if (empty($this->rowData[$externalMandateFieldName])) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
+  }
+
+  private function getRecurContributionCurrentMandateRecordIdIfExist() {
+    $sql = "SELECT id FROM civicrm_value_external_dd_mandate_information WHERE entity_id = %1";
+    $dao = SQLQueryRunner::executeQuery($sql, [
+      1 => [$this->recurContributionId, 'Int'],
+    ]);
+
+    $dao->fetch();
+    if (!empty($dao->id)) {
+      return $dao->id;
+    }
+
+    return NULL;
+  }
+
+  private function updateMandate($mandateRecordId) {
+    $sqlParams = $this->prepareSqlParams();
+    $sqlParams[5] = [$mandateRecordId, 'Integer'];
+    $sqlQuery = "UPDATE `civicrm_value_external_dd_mandate_information` SET
+                 entity_id = %1, `mandate_id` = %2, `mandate_status` = %3, `next_available_payment_date` = %4
+                 WHERE id = %5";
+    SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
+  }
+
+  private function createMandate() {
+    $sqlParams = $this->prepareSqlParams();
+    $sql = "INSERT INTO civicrm_value_external_dd_mandate_information
+            (entity_id, mandate_id, mandate_status, next_available_payment_date)
+            VALUES (%1, %2, %3, %4)";
+    SQLQueryRunner::executeQuery($sql, $sqlParams);
+
+    $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as mandate_id');
+    $dao->fetch();
+    return $dao->mandate_id;
+  }
+
+  private function prepareSqlParams() {
+    $nextPaymentDate = DateTime::createFromFormat('YmdHis', $this->rowData['external_direct_debit_next_available_payment_date']);
+    $mandateStatus = $this->rowData['external_direct_debit_mandate_status'] ?? 0;
+
+    return [
+      1 => [$this->recurContributionId, 'Integer'],
+      2 => [$this->rowData['external_direct_debit_mandate_id'], 'String'],
+      3 => [$mandateStatus, 'String'],
+      4 => [$nextPaymentDate->format('Ymd'), 'Date'],
+    ];
+  }
+
+}

--- a/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandate.php
@@ -252,7 +252,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandate {
 
   private function formatRowDate($dateColumnName, $columnLabel, $isRequired = FALSE) {
     if ($isRequired && empty($this->rowData[$dateColumnName])) {
-      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException("Direct Debit Mandate '{$columnLabel}' is required field.", 1200);
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException("Manual Direct Debit Mandate '{$columnLabel}' is required field.", 1200);
     }
 
     if (!empty($this->rowData[$dateColumnName])) {

--- a/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandate.php
@@ -2,7 +2,7 @@
 
 use CRM_Membershipextrasimporterapi_Helper_SQLQueryRunner as SQLQueryRunner;
 
-class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
+class CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandate {
 
   private $rowData;
 
@@ -22,7 +22,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
   }
 
   public function import() {
-    if (!$this->isDirectDebitPaymentProcessor()) {
+    if (!$this->isManualDirectDebitPaymentProcessor()) {
       return NULL;
     }
 
@@ -41,13 +41,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
       SQLQueryRunner::executeQuery($sql);
     }
     else {
-      $sql = "INSERT INTO `dd_contribution_recurr_mandate_ref` (`recurr_id` , `mandate_id`) 
+      $sql = "INSERT INTO `dd_contribution_recurr_mandate_ref` (`recurr_id` , `mandate_id`)
            VALUES ({$this->recurContributionId} , {$mandateId})";
       SQLQueryRunner::executeQuery($sql);
     }
 
     if ($this->isDirectDebitContribution() && !$this->isMandateContributionRefExist($mandateId)) {
-      $sql = "INSERT INTO `civicrm_value_dd_information` (`mandate_id` , `entity_id`) 
+      $sql = "INSERT INTO `civicrm_value_dd_information` (`mandate_id` , `entity_id`)
            VALUES ({$mandateId} , {$this->contributionId})";
       SQLQueryRunner::executeQuery($sql);
     }
@@ -55,7 +55,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
     return $mandateId;
   }
 
-  private function isDirectDebitPaymentProcessor() {
+  private function isManualDirectDebitPaymentProcessor() {
     if ($this->rowData['payment_plan_payment_processor'] == 'Direct Debit') {
       return TRUE;
     }
@@ -86,17 +86,17 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
   private function updateMandate($mandateId) {
     $sqlParams = $this->prepareSqlParams();
     $sqlParams[10] = [$mandateId, 'Integer'];
-    $sqlQuery = "UPDATE `civicrm_value_dd_mandate` SET  
-                `entity_id` = %1, `bank_name` = %2, `account_holder_name` = %3, `ac_number` = %4, `sort_code` = %5, 
-                `dd_code` = %6, `dd_ref` = %7, `start_date` = %8, `originator_number` = %9  
+    $sqlQuery = "UPDATE `civicrm_value_dd_mandate` SET
+                `entity_id` = %1, `bank_name` = %2, `account_holder_name` = %3, `ac_number` = %4, `sort_code` = %5,
+                `dd_code` = %6, `dd_ref` = %7, `start_date` = %8, `originator_number` = %9
                 WHERE id = %10";
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
   private function createMandate() {
     $sqlParams = $this->prepareSqlParams();
-    $sql = "INSERT INTO civicrm_value_dd_mandate 
-            (entity_id, bank_name, account_holder_name, ac_number, sort_code, dd_code, dd_ref, start_date, originator_number) 
+    $sql = "INSERT INTO civicrm_value_dd_mandate
+            (entity_id, bank_name, account_holder_name, ac_number, sort_code, dd_code, dd_ref, start_date, originator_number)
             VALUES (%1, %2, %3, %4, %5, %6, %7, %8, %9)";
     SQLQueryRunner::executeQuery($sql, $sqlParams);
 
@@ -106,7 +106,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
   }
 
   private function isRecurContributionAttachedToAnyMandate() {
-    $sql = "SELECT mandate_id FROM dd_contribution_recurr_mandate_ref  
+    $sql = "SELECT mandate_id FROM dd_contribution_recurr_mandate_ref
             WHERE recurr_id = {$this->recurContributionId}";
     $dao = SQLQueryRunner::executeQuery($sql);
 
@@ -127,7 +127,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
   }
 
   private function isMandateContributionRefExist($mandateId) {
-    $sql = "SELECT mandate_id FROM civicrm_value_dd_information  
+    $sql = "SELECT mandate_id FROM civicrm_value_dd_information
             WHERE mandate_id = %1 AND entity_id = %2";
     $dao = SQLQueryRunner::executeQuery($sql, [
       1 => [$mandateId, 'Integer'],
@@ -234,8 +234,8 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate {
     }
 
     if (!isset($this->cachedValues['originator_numbers'])) {
-      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov 
-                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id 
+      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov
+                  INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id
                   WHERE cog.name = 'direct_debit_originator_number'";
       $result = SQLQueryRunner::executeQuery($sqlQuery);
       while ($result->fetch()) {

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -275,4 +275,20 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'title' => 'Direct Debit Mandate Originator Number',
     'type' => CRM_Utils_Type::T_STRING,
   ];
+
+  // External Direct Debit fields
+  $params['external_direct_debit_mandate_id'] = [
+    'title' => 'External Direct Debit Mandate Id',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['external_direct_debit_mandate_status'] = [
+    'title' => 'External Direct Debit Mandate Status',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+
+  $params['external_direct_debit_next_available_payment_date'] = [
+    'title' => 'External Direct Debit Next Available Payment Date',
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
 }

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -45,13 +45,16 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
   $params['payment_plan_frequency'] = [
     'title' => 'Payment Plan Frequency',
     'type' => CRM_Utils_Type::T_STRING,
-    'api.required' => 1,
   ];
 
   $params['payment_plan_next_contribution_date'] = [
     'title' => 'Payment Plan Next Contribution Date',
     'type' => CRM_Utils_Type::T_DATE,
-    'api.required' => 1,
+  ];
+
+  $params['payment_plan_payment_scheme_id'] = [
+    'title' => 'Payment Plan Payment Scheme id',
+    'type' => CRM_Utils_Type::T_INT,
   ];
 
   $params['payment_plan_start_date'] = [

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -181,6 +181,11 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'type' => CRM_Utils_Type::T_STRING,
   ];
 
+  $params['contribution_owner_org_id'] = [
+    'title' => 'Contribution Owner organisation Id - For Multicompany accounting use only',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
   // Line Item
   $params['line_item_entity_table'] = [
     'title' => 'Order Line Entity Type',

--- a/api/v3/MembershipextrasImporter.php
+++ b/api/v3/MembershipextrasImporter.php
@@ -235,7 +235,7 @@ function _civicrm_api3_membershipextras_importer_create_spec(&$params) {
     'type' => CRM_Utils_Type::T_INT,
   ];
 
-  // Direct Debit Mandate
+  // Manual Direct Debit Mandate
   $params['direct_debit_mandate_reference'] = [
     'title' => 'Direct Debit Mandate Reference',
     'type' => CRM_Utils_Type::T_STRING,

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -12,6 +12,7 @@ abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements H
     return \Civi\Test::headless()
       ->install('uk.co.compucorp.membershipextras')
       ->install('uk.co.compucorp.manualdirectdebit')
+      ->install('io.compuco.automateddirectdebit')
       ->installMe(__DIR__)
       ->apply();
   }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandateTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate as ExternalDirectDebitMandateImporter;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
+
+/**
+ *
+ * @group headless
+ */
+class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandateTest extends BaseHeadlessTest {
+
+  private $contactId;
+
+  private $recurContributionId;
+
+  public function setUp() {
+    $this->contactId = ContactFabricator::fabricate()['id'];
+
+    $recurContributionParams = ['contact_id' => $this->contactId, 'amount' => 50, 'frequency_interval' => 1, 'payment_processor_id' => 1];
+    $this->recurContributionId = RecurContributionFabricator::fabricate($recurContributionParams)['id'];
+  }
+
+  public function testImportNewExternalDirectDebitMandate() {
+    $rowData = [
+      'external_direct_debit_mandate_id' => 'TEST_X13',
+      'external_direct_debit_mandate_status' => 1,
+      'external_direct_debit_next_available_payment_date' => '20230101000000',
+    ];
+    $mandateImporter = new ExternalDirectDebitMandateImporter($rowData, $this->recurContributionId);
+    $newMandateId = $mandateImporter->import();
+
+    $newMandate = $this->getExternalMandateById($newMandateId);
+    $this->assertEquals($rowData['external_direct_debit_mandate_id'], $newMandate['mandate_id']);
+    $this->assertEquals($rowData['external_direct_debit_mandate_status'], $newMandate['mandate_status']);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $rowData['external_direct_debit_next_available_payment_date']);
+    $this->assertEquals($expectedDate->format('Y-m-d H:i:s'), $newMandate['next_available_payment_date']);
+  }
+
+  public function testExternalMandateWillGetUpdatedIfRecurContributionAlreadyHasMandate() {
+    $firstImporterRowData = [
+      'external_direct_debit_mandate_id' => 'TEST_X13',
+      'external_direct_debit_mandate_status' => 1,
+      'external_direct_debit_next_available_payment_date' => '20230101000000',
+    ];
+    $mandateImporter = new ExternalDirectDebitMandateImporter($firstImporterRowData, $this->recurContributionId);
+    $firstImportMandateId = $mandateImporter->import();
+
+    $secondImporterRowData = [
+      'external_direct_debit_mandate_id' => 'TEST_X13',
+      'external_direct_debit_mandate_status' => 0,
+      'external_direct_debit_next_available_payment_date' => '20230301000000',
+    ];
+    $mandateImporter = new ExternalDirectDebitMandateImporter($secondImporterRowData, $this->recurContributionId);
+    $secondImportMandateId = $mandateImporter->import();
+
+    $newMandate = $this->getExternalMandateById($secondImportMandateId);
+    $this->assertEquals($firstImportMandateId, $secondImportMandateId);
+    $this->assertEquals($secondImporterRowData['external_direct_debit_mandate_id'], $newMandate['mandate_id']);
+    $this->assertEquals($secondImporterRowData['external_direct_debit_mandate_status'], $newMandate['mandate_status']);
+
+    $expectedDate = DateTime::createFromFormat('YmdHis', $secondImporterRowData['external_direct_debit_next_available_payment_date']);
+    $this->assertEquals($expectedDate->format('Y-m-d H:i:s'), $newMandate['next_available_payment_date']);
+  }
+
+  public function testNoMandateWillBeCreatedIfAnyMainMandateFieldIsMissing() {
+    $rowData = [
+      'external_direct_debit_mandate_id' => 'TEST_X13',
+      'external_direct_debit_next_available_payment_date' => '20230101000000',
+    ];
+
+    foreach ($rowData as $fieldName => $rowValue) {
+      $rowDataCopy = $rowData;
+      unset($rowDataCopy[$fieldName]);
+      $mandateImporter = new ExternalDirectDebitMandateImporter($rowDataCopy, $this->recurContributionId);
+      $newMandateId = $mandateImporter->import();
+
+      $this->assertNull($newMandateId);
+    }
+  }
+
+  private function getExternalMandateById($mandateId) {
+    $sql = "SELECT * FROM civicrm_value_external_dd_mandate_information WHERE id = {$mandateId}";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+
+    $dao->fetch();
+    if (!empty($dao->id)) {
+      return $dao->toArray();
+    }
+
+    return NULL;
+  }
+
+}

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ManualDirectDebitMandateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandate as DirectDebitMandateImporter;
+use CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandate as ManualDirectDebitMandateImporter;
 use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
 use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurContributionFabricator;
 use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
@@ -9,7 +9,7 @@ use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
  *
  * @group headless
  */
-class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest extends BaseHeadlessTest {
+class CRM_Membershipextrasimporterapi_EntityImporter_ManualDirectDebitMandateTest extends BaseHeadlessTest {
 
   private $sampleRowData = [
     'payment_plan_payment_processor' => 'Direct Debit',
@@ -66,7 +66,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   public function testImportWithNoDirectDebitPaymentProcessorWillNotCreateMandate() {
     $this->sampleRowData['payment_plan_payment_processor'] = 'Paypal';
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $this->assertEmpty($newMandateId);
@@ -77,14 +77,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(100);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportNewDirectDebitMandate() {
     $beforeImportIds = $this->getMandateIdByReference($this->sampleRowData['direct_debit_mandate_reference']);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $afterImportIds = $this->getMandateIdByReference($this->sampleRowData['direct_debit_mandate_reference']);
@@ -103,12 +103,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(200);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectBankNameValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -122,12 +122,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(300);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectAccountHolderValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -141,7 +141,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(400);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -151,7 +151,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(500);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -161,12 +161,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(500);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectAccountNumberValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -180,7 +180,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(600);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -190,7 +190,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(700);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -200,12 +200,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(700);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectSortCodeValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -219,7 +219,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(800);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -229,12 +229,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(900);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectDDCodeValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -249,12 +249,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(1200);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectStartDateValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -269,7 +269,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(1000);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
@@ -279,12 +279,12 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidDirectDebitMandateException::class);
     $this->expectExceptionCode(1100);
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
   }
 
   public function testImportSetsCorrectOriginatorNumberValue() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -293,7 +293,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   }
 
   public function testImportSetsCorrectContactId() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandate = $this->getMandateById($newMandateId);
@@ -302,7 +302,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   }
 
   public function testImportNewCreatesRecurContributionReferenceRecord() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandates = $this->getMandateRecurContributionReferences();
@@ -312,7 +312,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   }
 
   public function testImportNewCreatesContributionReferenceRecord() {
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $newMandateId = $mandateImporter->import();
 
     $mandates = $this->getMandateContributionReferences();
@@ -324,7 +324,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   public function testImportWillNotCreateContributionReferenceRecordIfContributionPaymentMethodIsNotDirectDebit() {
     $this->sampleRowData['contribution_payment_method'] = 'EFT';
 
-    $mandateImporter = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $mandateImporter = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $mandateImporter->import();
 
     $mandates = $this->getMandateContributionReferences();
@@ -333,7 +333,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
   }
 
   public function testImportExistingMandateWillUpdateItCorrectly() {
-    $firstImport = new DirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $firstImport = new ManualDirectDebitMandateImporter($this->sampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $firstMandateId = $firstImport->import();
 
     $updatedSampleRowData = [
@@ -348,7 +348,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_DirectDebitMandateTest exte
       'direct_debit_mandate_start_date' => '20220101000000',
       'direct_debit_mandate_originator_number' => 'Test Originator',
     ];
-    $secondImport = new DirectDebitMandateImporter($updatedSampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
+    $secondImport = new ManualDirectDebitMandateImporter($updatedSampleRowData, $this->contactId, $this->recurContributionId, $this->contributionId);
     $secondImport->import();
 
     $expectedResult = [

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/RecurContributionTest.php
@@ -11,7 +11,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
   private $sampleRowData = [
     'payment_plan_external_id' => 'test1',
     'payment_plan_payment_processor' => 'Offline Recurring Contribution',
-    'payment_plan_frequency' => 'month',
+    'payment_plan_frequency' => 'monthly',
     'payment_plan_next_contribution_date' => '20210101000000',
     'payment_plan_start_date' => '20200101000000',
     'payment_plan_create_date' => '20190101000000',
@@ -84,7 +84,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportYearlyRecurContributionWillSetCorrectFrequencyInformation() {
     $this->sampleRowData['payment_plan_external_id'] = 'test6';
-    $this->sampleRowData['payment_plan_frequency'] = 'year';
+    $this->sampleRowData['payment_plan_frequency'] = 'annual';
 
     $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
     $newRecurContributionId = $recurContributionImporter->import();
@@ -237,7 +237,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportYearlyRecurContributionWillNotSetCycleDay() {
     $this->sampleRowData['payment_plan_external_id'] = 'test19';
-    $this->sampleRowData['payment_plan_frequency'] = 'year';
+    $this->sampleRowData['payment_plan_frequency'] = 'annual';
 
     $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
     $newRecurContributionId = $recurContributionImporter->import();
@@ -249,7 +249,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportMonthlyRecurContributionWithNoCycleDayWillThrowAnException() {
     $this->sampleRowData['payment_plan_external_id'] = 'test20';
-    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_frequency'] = 'monthly';
     unset($this->sampleRowData['payment_plan_cycle_day']);
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
@@ -261,7 +261,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportMonthlyRecurContributionWithCycleDayLessThanOneWillThrowAnException() {
     $this->sampleRowData['payment_plan_external_id'] = 'test21';
-    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_frequency'] = 'monthly';
     $this->sampleRowData['payment_plan_cycle_day'] = -1;
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
@@ -273,7 +273,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportMonthlyRecurContributionWithCycleDayEqual28WillThrowAnException() {
     $this->sampleRowData['payment_plan_external_id'] = 'test22';
-    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_frequency'] = 'monthly';
     $this->sampleRowData['payment_plan_cycle_day'] = 28;
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
@@ -285,7 +285,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportMonthlyRecurContributionWithCycleDayLargerThan28WillThrowAnException() {
     $this->sampleRowData['payment_plan_external_id'] = 'test23';
-    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_frequency'] = 'monthly';
     $this->sampleRowData['payment_plan_cycle_day'] = 29;
 
     $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
@@ -297,7 +297,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
 
   public function testImportMonthlyRecurContributionWillSetCorrectCycleDayValue() {
     $this->sampleRowData['payment_plan_external_id'] = 'test24';
-    $this->sampleRowData['payment_plan_frequency'] = 'month';
+    $this->sampleRowData['payment_plan_frequency'] = 'monthly';
 
     $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
     $newRecurContributionId = $recurContributionImporter->import();
@@ -383,17 +383,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     $expectedDate = $expectedDate->format('Y-m-d H:i:s');
 
     $this->assertEquals($expectedDate, $newRecurContribution['next_sched_contribution_date']);
-  }
-
-  public function testImportWithNoNextContributionDateWillThrowAnException() {
-    $this->sampleRowData['payment_plan_external_id'] = 'test30';
-    unset($this->sampleRowData['payment_plan_next_contribution_date']);
-
-    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
-    $this->expectExceptionCode(800);
-
-    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
-    $recurContributionImporter->import();
   }
 
   public function testImportWithInvalidCurrencyThrowAnException() {
@@ -530,7 +519,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     $updatedSampleRowData = [
       'payment_plan_external_id' => 'test38',
       'payment_plan_payment_processor' => 'Offline Recurring Contribution',
-      'payment_plan_frequency' => 'year',
+      'payment_plan_frequency' => 'annual',
       'payment_plan_next_contribution_date' => '20220101000000',
       'payment_plan_start_date' => '20210101000000',
       'payment_plan_create_date' => '20200101000000',
@@ -574,6 +563,54 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContributionTest exten
     ];
 
     $this->assertEquals($expectedResult, $actualResult);
+  }
+
+  public function testThatEitherPaymentSchemeOrPaymentPlanFrequencyIsRequired() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test39';
+    unset($this->sampleRowData['payment_plan_frequency']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(1300);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testThatNextContributionDateIsRequiredIfPaymentFrequencyIsUsed() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test40';
+    unset($this->sampleRowData['payment_plan_next_contribution_date']);
+
+    $this->expectException(CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException::class);
+    $this->expectExceptionCode(1400);
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $recurContributionImporter->import();
+  }
+
+  public function testPaymentSchemeWillBeSetCorrectly() {
+    $this->sampleRowData['payment_plan_external_id'] = 'test41';
+    unset($this->sampleRowData['payment_plan_frequency']);
+
+    $paymentScheme = CRM_MembershipExtras_BAO_PaymentScheme::create([
+      'name' => 'Test scheme',
+      'admin_title' => 'Admin title',
+      'public_title' => 'Public title',
+      'public_description' => 'Public description',
+      'permission' => 'public',
+      'enabled' => TRUE,
+      'parameters' => '{}',
+      'payment_processor' => 1,
+    ]);
+    $this->sampleRowData['payment_plan_payment_scheme_id'] = $paymentScheme->id;
+
+    $recurContributionImporter = new RecurContributionImporter($this->sampleRowData, $this->contactId);
+    $newRecurContributionId = $recurContributionImporter->import();
+
+    $sqlQuery = "SELECT payment_scheme_id FROM civicrm_value_payment_plan_extra_attributes WHERE entity_id = {$newRecurContributionId}";
+    $result = CRM_Core_DAO::executeQuery($sqlQuery);
+    $result->fetch();
+
+    $this->assertEquals($paymentScheme->id, $result->payment_scheme_id);
   }
 
   private function getRecurContributionsByContactId($contactId) {


### PR DESCRIPTION
This PR Introduces the following changes:

## Allow importing payment schemes

As part of the work we are doing here: https://github.com/compucorp/uk.co.compucorp.membershipextras/tree/CIWEMB-84-workstream , we are allowing creating payment plans to be paid using the traditional payment plan frequencies (monthly, quarterly, annual) or using payment schemes, new field is added to the importer called `payment_plan_payment_scheme_id` , which allows to import such field.

I've also changed the validation so that either:

1- The `payment_plan_frequency` and `payment_plan_next_contribution_date` are provided (hence that the `next scheduled contribution date`  is important for the traditional payment plans autorenewal to work properly).
2- Or alternatively the `payment_plan_payment_scheme_id` is provided..

If the `payment_plan_payment_scheme_id` field is used, we assume that the payment schemes are already created and configured on CiviCRM before the import process.


As part of this update, I've also changed the allowed options for the `payment_plan_frequency` field, so instead of only allowing "month" (for monthly payment plans) or "year" (for annual payment plans) as acceptable values, I've changed it to accept "monthly", "annual" and "quarterly" for better clarity. 

## Adding support for importing external Direct debit mandates.

The importer only provided support for importing Manual Direct debit mandates that are provided by this extension (https://github.com/compucorp/uk.co.compucorp.manualdirectdebit) , but given we are working on Direct debit support for non manual Direct debit processors such as GoCardless and Stripe, With this PR I now allow importing 3 extra fields which are:

- `external_direct_debit_mandate_id`
- `external_direct_debit_mandate_status`
- `external_direct_debit_next_available_payment_date`

These fields are provided by this extension https://github.com/compucorp/io.compuco.automateddirectdebit , which is meant to be used with GoCardless and Stripe payment processors to store such payment processors relevant mandates information.


Also as result of this, I've changed the class that is responsible for importing Manual Direct debit mandates from `DirectDebitMandate` to `ManualDirectDebitMandate`  for better clarity and to distinguish it from the the `ExternalDirectDebitMandate` class that I've added.


## Adding support for Multicompany accounting

This extension https://github.com/compucorp/io.compuco.multicompanyaccounting provides support for multi company accounting, and for it work properly each contribution should have an "owner organization", I've added new field to this importer called: `contribution_owner_org_id` that allows importing such field.