### PR TITLE
CIWEMSPRT-13: Add support for GoCardless payment processor and use financeextras instead of multicompanyaccounting extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.manualdirectdebit.git
-          git clone --depth 1 https://github.com/compucorp/io.compuco.multicompanyaccounting.git
+          git clone --depth 1 https://github.com/compucorp/io.compuco.financeextras.git
           git clone --depth 1 https://github.com/compucorp/io.compuco.automateddirectdebit.git
           git clone --depth 1 -b 1.10-patches https://github.com/compucorp/nz.co.fuzion.csvimport.git
-          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit io.compuco.automateddirectdebit nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
+          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit io.compuco.automateddirectdebit io.compuco.financeextras nz.co.fuzion.csvimport uk.co.compucorp.membershipextrasimporterapi
 
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextrasimporterapi

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -184,13 +184,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
   }
 
   private function getContributionStatusId() {
-    $statusName = 'Completed';
+    $statusName = 'completed';
     if (!empty($this->rowData['contribution_status'])) {
-      $statusName = $this->rowData['contribution_status'];
+      $statusName = strtolower($this->rowData['contribution_status']);
     }
 
     if (!isset($this->cachedValues['contribution_statuses'])) {
-      $sqlQuery = "SELECT cov.name as name, cov.value as id FROM civicrm_option_value cov
+      $sqlQuery = "SELECT LOWER(cov.name) as name, cov.value as id FROM civicrm_option_value cov
                   INNER JOIN civicrm_option_group cog ON cov.option_group_id = cog.id
                   WHERE cog.name = 'contribution_status'";
       $result = SQLQueryRunner::executeQuery($sqlQuery);

--- a/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/Contribution.php
@@ -300,7 +300,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_Contribution {
       return;
     }
 
-    $sqlQuery = "INSERT INTO `civicrm_value_multicompanyaccounting_ownerorg` (`entity_id` , `owner_organization`)
+    $sqlQuery = "INSERT INTO `civicrm_value_financeextras_contribution_ownerorg` (`entity_id` , `owner_organization`)
            VALUES ({$contributionId}, %1)";
     SQLQueryRunner::executeQuery($sqlQuery, [1 => [$this->rowData['contribution_owner_org_id'], 'Integer']]);
   }

--- a/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/LineItem.php
@@ -358,14 +358,14 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $toFinancialAccountId = $this->getFinancialAccountIdByRelationship($mappedLineItemParams['financial_type_id'], $incomeAccountRelationshipId);
 
     $sqlParams = [
-      1 => [$this->contribution['contact_id'], 'Integer'],
+      1 => [intval($this->contribution['contact_id']), 'Integer'],
       2 => [$mappedLineItemParams['line_item_label'], 'String'],
       3 => [$mappedLineItemParams['line_total'], 'Money'],
       4 => [$this->contribution['currency'], 'String'],
-      5 => [$toFinancialAccountId, 'Integer'],
-      6 => [$this->getFinancialItemStatusId(), 'Integer'],
+      5 => [intval($toFinancialAccountId), 'Integer'],
+      6 => [intval($this->getFinancialItemStatusId()), 'Integer'],
       7 => ['civicrm_line_item', 'String'],
-      8 => [$lineItemId, 'Integer'],
+      8 => [intval($lineItemId), 'Integer'],
       9 => [$this->contribution['receive_date'], 'String'],
     ];
     $sqlQuery = "INSERT INTO `civicrm_financial_item` (`contact_id` , `description` , `amount` , `currency` ,
@@ -384,15 +384,19 @@ class CRM_Membershipextrasimporterapi_EntityImporter_LineItem {
     $salesTaxAccountRelationshipId = 10;
     $toFinancialAccountId = $this->getFinancialAccountIdByRelationship($mappedLineItemParams['financial_type_id'], $salesTaxAccountRelationshipId);
 
+    if (empty($toFinancialAccountId)) {
+      throw new CRM_Membershipextrasimporterapi_Exception_InvalidLineItemException('Line Item has tax amount but Financial type has no sales tax account', 300);
+    }
+
     $sqlParams = [
-      1 => [$this->contribution['contact_id'], 'Integer'],
+      1 => [intval($this->contribution['contact_id']), 'Integer'],
       2 => ['Sales Tax', 'String'],
       3 => [$mappedLineItemParams['tax_amount'], 'Money'],
       4 => [$this->contribution['currency'], 'String'],
-      5 => [$toFinancialAccountId, 'Integer'],
-      6 => [$this->getFinancialItemStatusId(), 'Integer'],
+      5 => [intval($toFinancialAccountId), 'Integer'],
+      6 => [intval($this->getFinancialItemStatusId()), 'Integer'],
       7 => ['civicrm_line_item', 'String'],
-      8 => [$lineItemId, 'Integer'],
+      8 => [intval($lineItemId), 'Integer'],
       9 => [$this->contribution['receive_date'], 'String'],
     ];
     $sqlQuery = "INSERT INTO `civicrm_financial_item` (`contact_id` , `description` , `amount` , `currency` ,

--- a/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/RecurContribution.php
@@ -255,9 +255,9 @@ class CRM_Membershipextrasimporterapi_EntityImporter_RecurContribution {
 
     $paymentProcessorName = $this->rowData['payment_plan_payment_processor'];
     if (!empty($this->cachedValues['payment_processors'][$paymentProcessorName])) {
-      $offlinePaymentProcessorClassName = 'Payment_Manual';
-      if ($this->cachedValues['payment_processors'][$paymentProcessorName]['class_name'] != $offlinePaymentProcessorClassName) {
-        throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Only Manual payment plan "Payment Processors"', 1200);
+      $supportedPaymentProcessorClassname = ['Payment_Manual', 'Payment_GoCardless'];
+      if (!in_array($this->cachedValues['payment_processors'][$paymentProcessorName]['class_name'], $supportedPaymentProcessorClassname)) {
+        throw new CRM_Membershipextrasimporterapi_Exception_InvalidRecurContributionFieldException('Only GoCardless and Manual payment plan "Payment Processors"', 1200);
       }
 
       return $this->cachedValues['payment_processors'][$paymentProcessorName]['id'];

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -13,6 +13,7 @@ abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements H
       ->install('uk.co.compucorp.membershipextras')
       ->install('uk.co.compucorp.manualdirectdebit')
       ->install('io.compuco.automateddirectdebit')
+      ->install('io.compuco.financeextras')
       ->installMe(__DIR__)
       ->apply();
   }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
@@ -347,7 +347,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends Ba
 
   public function testImportWillSetOwnerOrgIdIfItIsAvailable() {
     civicrm_api3('Extension', 'install', [
-      'keys' => "io.compuco.multicompanyaccounting",
+      'keys' => "io.compuco.financeextras",
     ]);
 
     $this->sampleRowData['contribution_external_id'] = 'test24';
@@ -356,13 +356,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ContributionTest extends Ba
     $contributionImporter = new ContributionImporter($this->sampleRowData, $this->contactId, $this->recurContributionId);
     $newContributionId = $contributionImporter->import();
 
-    $sqlQuery = "SELECT owner_organization FROM civicrm_value_multicompanyaccounting_ownerorg WHERE entity_id = {$newContributionId}";
+    $sqlQuery = "SELECT owner_organization FROM civicrm_value_financeextras_contribution_ownerorg WHERE entity_id = {$newContributionId}";
     $storedOwnerOrgID = CRM_Core_DAO::singleValueQuery($sqlQuery);
 
     $this->assertEquals($this->contactId, $storedOwnerOrgID);
 
     civicrm_api3('Extension', 'disable', [
-      'keys' => "io.compuco.multicompanyaccounting",
+      'keys' => "io.compuco.financeextras",
     ]);
   }
 


### PR DESCRIPTION
## Overview
Before this PR, users could only import contributions with Payment Plan processor, we have now added support for the GoCardless payment processor.

Also:
 - we have to ensure the contribution status is no longer case-sensitive. So a contribution status could be either `Completed` or `Completed`.
-  we updated the multi-company custom value to that created in the [financeextras extension](https://github.com/compucorp/io.compuco.financeextras/blob/5cbd61459474e05055dc211dcef1859c2b290400/xml/customFields_install.xml#L5)
- Add new custom exception for line-item with tax and invalid financial type.

## Before

The Import fails with the following error in the CSV

<img width="968" alt="Screenshot 2024-05-03 at 09 22 08" src="https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/assets/85277674/67f7a445-d6c5-4c79-8349-6cf6981ab4fd">


## After
The error is no longer returned
