### PR TITLE
CIVIMM-263: payment_plan_mandate_next_available_payment_date should not be mandatory in MAE importer

### DIFF
--- a/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
+++ b/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandate.php
@@ -30,7 +30,7 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate 
   }
 
   private function isExternalMandateInformationAvailable() {
-    $externalMandateFields = ['external_direct_debit_mandate_id', 'external_direct_debit_next_available_payment_date'];
+    $externalMandateFields = ['external_direct_debit_mandate_id'];
     foreach ($externalMandateFields as $externalMandateFieldName) {
       if (empty($this->rowData[$externalMandateFieldName])) {
         return FALSE;
@@ -56,10 +56,15 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate 
 
   private function updateMandate($mandateRecordId) {
     $sqlParams = $this->prepareSqlParams();
-    $sqlParams[5] = [$mandateRecordId, 'Integer'];
+    $sqlParams[count($sqlParams) + 1] = [$mandateRecordId, 'Integer'];
     $sqlQuery = "UPDATE `civicrm_value_external_dd_mandate_information` SET
                  entity_id = %1, `mandate_id` = %2, `mandate_status` = %3, `next_available_payment_date` = %4
                  WHERE id = %5";
+    if ($this->emptyNextPaymentdate()) {
+      $sqlQuery = "UPDATE `civicrm_value_external_dd_mandate_information` SET
+                 entity_id = %1, `mandate_id` = %2, `mandate_status` = %3 
+                 WHERE id = %4";
+    }
     SQLQueryRunner::executeQuery($sqlQuery, $sqlParams);
   }
 
@@ -68,6 +73,13 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate 
     $sql = "INSERT INTO civicrm_value_external_dd_mandate_information
             (entity_id, mandate_id, mandate_status, next_available_payment_date)
             VALUES (%1, %2, %3, %4)";
+
+    if ($this->emptyNextPaymentdate()) {
+      $sql = "INSERT INTO civicrm_value_external_dd_mandate_information
+            (entity_id, mandate_id, mandate_status)
+            VALUES (%1, %2, %3)";
+    }
+
     SQLQueryRunner::executeQuery($sql, $sqlParams);
 
     $dao = SQLQueryRunner::executeQuery('SELECT LAST_INSERT_ID() as mandate_id');
@@ -76,15 +88,27 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandate 
   }
 
   private function prepareSqlParams() {
-    $nextPaymentDate = DateTime::createFromFormat('YmdHis', $this->rowData['external_direct_debit_next_available_payment_date']);
+    $nextPaymentDate = NULL;
+    if (!$this->emptyNextPaymentdate()) {
+      $nextPaymentDate = DateTime::createFromFormat('YmdHis', $this->rowData['external_direct_debit_next_available_payment_date']);
+    }
     $mandateStatus = $this->rowData['external_direct_debit_mandate_status'] ?? 0;
 
-    return [
+    $sqlParams = [
       1 => [$this->recurContributionId, 'Integer'],
       2 => [$this->rowData['external_direct_debit_mandate_id'], 'String'],
       3 => [$mandateStatus, 'String'],
-      4 => [$nextPaymentDate->format('Ymd'), 'Date'],
     ];
+
+    if (!$this->emptyNextPaymentdate()) {
+      $sqlParams[4] = [$nextPaymentDate->format('Ymd'), 'Date'];
+    }
+
+    return $sqlParams;
+  }
+
+  private function emptyNextPaymentdate() {
+    return empty($this->rowData['external_direct_debit_next_available_payment_date']);
   }
 
 }

--- a/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandateTest.php
+++ b/tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ExternalDirectDebitMandateTest.php
@@ -67,7 +67,6 @@ class CRM_Membershipextrasimporterapi_EntityImporter_ExternalDirectDebitMandateT
   public function testNoMandateWillBeCreatedIfAnyMainMandateFieldIsMissing() {
     $rowData = [
       'external_direct_debit_mandate_id' => 'TEST_X13',
-      'external_direct_debit_next_available_payment_date' => '20230101000000',
     ];
 
     foreach ($rowData as $fieldName => $rowValue) {


### PR DESCRIPTION
## Overview  
Previously, when importing a recurring contribution with mandate information, the system ignored the entire mandate information if the `next_available_payment_date` field was missing.  

This PR ensures the  mandate `next_available_payment_date` is optional.

## Before  
_No UI changes._  

## After  
_No UI changes._  

