### PR TITLE
CIVIMM-483: Add AI development playbooks for Claude, Gemini, and Codex

### DIFF
--- a/.ai/ai-code-review.md
+++ b/.ai/ai-code-review.md
@@ -1,0 +1,158 @@
+<!-- .ai/ai-code-review.md v1.5 | Last updated: 2026-02-17 -->
+
+# AI Code Review Guide
+
+This document defines how **any AI tool** (Claude, Gemini, Codex, or others) should review code changes. The review process is tool-agnostic -- the diff is the universal input, the standards are shared.
+
+> **Standards reference:** [shared-development-guide.md](shared-development-guide.md)
+
+---
+
+## 1. Review Modes
+
+### Pre-Push Review (Developer-Initiated)
+
+Review changes **before** pushing to remote. Works with any AI tool or interface (IDE, CLI, web chat).
+
+**Step 1: Generate the diff**
+
+Determine your base branch first (e.g., `master`, `main`, `develop`). Use the base branch your PR will target.
+
+```bash
+# All committed changes on current branch vs base branch
+git diff <base-branch>...HEAD
+
+# Only staged changes (not yet committed)
+git diff --cached
+
+# Only unstaged changes
+git diff
+
+# Specific files
+git diff <base-branch>...HEAD -- path/to/file.php
+
+# Example with master as base
+git diff master...HEAD
+```
+
+> **Tip:** For a complete review, check both committed changes (`git diff <base-branch>...HEAD`) and any uncommitted work (`git diff`, `git diff --cached`).
+
+**Step 2: Request the review**
+
+Use this prompt template (adapt wording for your tool):
+
+```
+Review the following code changes against our project's coding standards
+in SHARED_DEVELOPMENT_GUIDE.md.
+
+Check for:
+- Security issues (SQL injection, XSS, hardcoded secrets)
+- Performance problems (N+1 queries, inefficient loops)
+- Code quality (SRP, naming, error handling, type safety)
+- Test coverage (are new features/fixes tested?)
+- PHPStan compliance (proper types, no mixed where avoidable)
+- Linting compliance (CiviCRM Drupal standards)
+
+For each issue, provide:
+- Severity: BLOCKER / WARNING / SUGGESTION / QUESTION
+- File and line reference
+- What the issue is and why it matters
+- Suggested fix
+
+<paste diff here>
+```
+
+**Step 3: Act on feedback**
+
+- Fix BLOCKERs before pushing
+- Address WARNINGs where practical
+- Consider SUGGESTIONs for follow-up
+- Answer QUESTIONs with code comments or commit messages
+
+### GitHub PR Review (Automated)
+
+Review changes **after** pushing, on the Pull Request. The AI tool reads the PR diff automatically (base branch is known from the PR target).
+
+Same checklist applies. The AI tool should post comments on specific lines.
+
+---
+
+## 2. Review Checklist
+
+### Standards Compliance
+- [ ] Commit messages follow `TICKET-###:` format
+- [ ] PR uses `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] All required sections filled (Overview, Before, After, Technical Details)
+- [ ] No AI attribution in commits
+
+### Security
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] Parameterized queries (no SQL injection)
+- [ ] User input sanitized before rendering (no XSS)
+- [ ] Webhook signatures verified
+- [ ] Authentication/authorization on API endpoints
+- [ ] Sensitive files not committed (`civicrm.settings.php`, `.env`)
+
+### Performance
+- [ ] No N+1 query issues
+- [ ] No inefficient loops over large datasets
+- [ ] Unnecessary API calls avoided
+- [ ] Database queries optimized
+
+### Code Quality
+- [ ] Single responsibility principle followed
+- [ ] Meaningful names following project conventions
+- [ ] Proper exception handling
+- [ ] Return type declarations on service methods
+- [ ] Dependency injection used
+- [ ] Proper types in PHPDoc (no `mixed` where avoidable)
+- [ ] No `assert()` in production code
+
+### Testing
+- [ ] New features and bug fixes include tests
+- [ ] Tests cover positive, negative, and edge cases
+- [ ] No tests removed or weakened
+- [ ] Error message changes reflected in test assertions
+
+### Static Analysis & Linting
+- [ ] Coding standards followed
+- [ ] Files end with newlines
+- [ ] `@phpstan-param` / `@phpstan-var` used where linter and PHPStan conflict
+
+---
+
+## 3. Review Severity Levels
+
+| Level | Meaning | Action Required |
+|-------|---------|-----------------|
+| **BLOCKER** | Security vulnerability, data loss risk, broken functionality | Must fix before merge |
+| **WARNING** | Affects quality, performance, or maintainability | Should fix before merge |
+| **SUGGESTION** | Optional improvement | Nice to have, can be follow-up |
+| **QUESTION** | Needs clarification from the author | Author must respond |
+
+---
+
+## 4. Review Feedback Principles
+
+- **Be specific** -- reference file paths and line numbers
+- **Explain why** -- not just what to change, but why it matters
+- **Think critically** -- don't suggest changes that contradict architectural decisions
+- **Consider implications** -- type changes, database constraints, performance trade-offs
+- **Distinguish severity** -- not everything is a blocker
+- **Be constructive** -- suggest fixes, not just problems
+
+---
+
+## 5. Cross-Tool Review Workflow
+
+Any combination works:
+
+| Developer Tool | Reviewer Tool | How |
+|---------------|---------------|-----|
+| Claude | Gemini | Push branch, Gemini reviews PR or diff |
+| Gemini | Claude | Feed diff to Claude in new session |
+| Human | Any AI | Feed diff or create PR |
+| Codex | Claude/Gemini | Push branch, other tool reviews |
+| Any tool | Same tool (new session) | Feed diff to fresh session for unbiased review |
+
+**Best practice:** Use a **different tool or session** for review than was used for development. Fresh context catches more issues.

--- a/.ai/civicrm.md
+++ b/.ai/civicrm.md
@@ -1,0 +1,223 @@
+<!-- .ai/civicrm.md v1.5 | Last updated: 2026-02-17 -->
+
+# CiviCRM Core Reference
+
+This file provides CiviCRM-specific patterns and conventions for AI tools and developers.
+
+> **Extension structure & testing:** See [extension.md](extension.md) for extension directory layout, schema changes, and testing patterns.
+
+---
+
+## 1. Namespaces
+
+| Namespace | Directory | Purpose |
+|-----------|-----------|---------|
+| `CRM_*` | `CRM/` | Traditional CiviCRM (DAO, BAO, Pages, Forms) |
+| `Civi\ExtensionName\*` | `Civi/` | Modern services, hooks, factories |
+
+---
+
+## 2. CiviCRM API Usage
+
+### Prefer API4 Over API3
+
+API4 is the modern CiviCRM API with better type safety and cleaner syntax. Use it for all new code.
+
+```php
+// API4 with permission bypass for internal/IPN operations
+$contribution = \Civi\Api4\Contribution::get(FALSE)
+  ->addSelect('id', 'contribution_page_id', 'contribution_status_id:name')
+  ->addWhere('id', '=', $contributionId)
+  ->execute()
+  ->first();
+
+// API3 (legacy - avoid in new code)
+$contribution = civicrm_api3('Contribution', 'getsingle', [
+  'id' => $contributionId,
+  'return' => ['id', 'contribution_page_id'],
+]);
+```
+
+### Key API4 Differences
+- `FALSE` as first parameter bypasses permission checks
+- API3 requires `'check_permissions' => 0` (easy to forget)
+- API4 uses `snake_case` field names consistently
+- API4 status fields use pseudoconstant syntax: `contribution_status_id:name`
+
+### When to Bypass Permissions (API4 `FALSE`)
+- IPN/webhook handlers (anonymous context)
+- Return URLs from payment processors
+- Internal service operations
+- Background processing jobs
+
+### When API3 Is Acceptable
+- Entity not yet available in API4 (rare)
+- Maintaining consistency with existing code in same method
+- `Payment.create` API (commonly used, works well)
+
+---
+
+## 3. API4 Result Handling & PHPStan
+
+API4's `->first()` and `->single()` return `mixed`. Use these patterns for PHPStan compliance:
+
+### In Services - `is_array()` Guard
+```php
+$result = \Civi\Api4\PaymentToken::create(FALSE)
+  ->setValues($tokenParams)
+  ->execute()
+  ->first();
+
+if (!is_array($result) || empty($result['id'])) {
+  throw new \CRM_Core_Exception('Failed to create payment token');
+}
+return $result;
+```
+
+### In Tests - `assertNotNull()` Before Accessing
+```php
+$updated = \Civi\Api4\ContributionRecur::get(FALSE)
+  ->addSelect('payment_token_id')
+  ->addWhere('id', '=', $recurId)
+  ->execute()
+  ->first();
+
+$this->assertNotNull($updated);
+$this->assertEquals($tokenId, $updated['payment_token_id']);
+```
+
+### Avoid These Patterns
+```php
+// BAD: Inline @var annotations - not the project pattern
+/** @var array{id: int}|null $result */
+$result = $api->execute()->first();
+
+// BAD: ->single() throws if not exactly 1 result
+// Use ->first() with is_array() check instead
+$result = $api->execute()->single();
+```
+
+---
+
+## 4. PHPStan Stub Files for Dynamic Classes
+
+CiviCRM Api4 entity classes are **dynamically generated at runtime** and have no physical PHP files. Use stub files in `stubs/`:
+
+```php
+// stubs/CiviApi4.stub.php
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\DAOGetAction;
+use Civi\Api4\Generic\DAOCreateAction;
+use Civi\Api4\Generic\DAOUpdateAction;
+use Civi\Api4\Generic\DAODeleteAction;
+
+/**
+ * @method static DAOGetAction get(bool $checkPermissions = TRUE)
+ * @method static DAOCreateAction create(bool $checkPermissions = TRUE)
+ * @method static DAOUpdateAction update(bool $checkPermissions = TRUE)
+ * @method static DAODeleteAction delete(bool $checkPermissions = TRUE)
+ */
+class Activity {
+
+}
+```
+
+**Rules:**
+- Do NOT use `extends AbstractEntity` in stubs (causes CI errors)
+- Add new Api4 entities to the stub file when first used
+- Referenced in both `phpstan.neon` and CI-generated `phpstan-ci.neon`
+
+---
+
+## 5. Hooks and Integration Points
+
+Common CiviCRM hooks used in extensions:
+
+| Hook | Purpose |
+|------|---------|
+| `civicrm_buildForm` | Inject scripts/templates into forms |
+| `civicrm_validateForm` | Validate form submissions |
+| `civicrm_permission` | Register custom permissions |
+| `civicrm_permission_check` | Grant permissions dynamically |
+| `civicrm_container` | Register services with DI container |
+| `civicrm_postCommit` | Handle post-transaction tasks |
+| `civicrm_check` | System status checks |
+
+---
+
+## 6. Service Registration
+
+Services are registered via Symfony DI container in hook implementations:
+
+```php
+// In Civi/ExtensionName/Hook/Container/ServiceContainer.php
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ServiceContainer {
+  public function register(ContainerBuilder $container): void {
+    $definition = new Definition(MyService::class);
+    $definition->addArgument(new Reference('other.service'));
+    $container->setDefinition('my.service', $definition);
+  }
+}
+```
+
+Usage:
+```php
+$service = \Civi::service('my.service');
+```
+
+---
+
+## 7. Common CiviCRM Commands
+
+```bash
+# Enable extension
+cv en extension_name
+
+# Disable extension
+cv dis extension_name
+
+# Uninstall extension
+cv ext:uninstall extension_name
+
+# Upgrade extension
+cv api Extension.upgrade
+
+# Clear cache
+cv flush
+```
+
+---
+
+## 8. PHPStan vs Linter Compatibility
+
+The Drupal linter and PHPStan have conflicting requirements for array type annotations.
+
+**Problem:** `@var array<string, string|int>` fails linter, but `@var array` fails PHPStan.
+
+**Solution:** Use `@phpstan-var` / `@phpstan-param` which PHPStan reads but linter ignores:
+
+```php
+/**
+ * @param array $params
+ * @phpstan-param array<string, mixed> $params
+ */
+public function process(array $params): void {
+  // ...
+}
+
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-var array<string, string|int>
+ */
+protected static $defaultParams = [
+  'financial_type_id' => 'Donation',
+  'frequency_interval' => 1,
+];
+```
+
+For inherited properties, use `{@inheritdoc}` plus `@phpstan-var` for the specific type.

--- a/.ai/extension.md
+++ b/.ai/extension.md
@@ -1,0 +1,85 @@
+<!-- .ai/extension.md v1.5 | Last updated: 2026-02-17 -->
+
+# CiviCRM Extension Development
+
+This file covers extension-specific structure, schema management, and testing patterns.
+
+> **CiviCRM core patterns:** See [civicrm.md](civicrm.md) for API4, hooks, services, and PHPStan patterns.
+
+---
+
+## 1. Extension Structure
+
+```
+extension-root/
+  info.xml              # Extension metadata, dependencies, version
+  *.php                 # Hook implementations entry point
+  *.civix.php           # Auto-generated CiviX boilerplate (DO NOT EDIT)
+  CRM/                  # Traditional CiviCRM namespace (CRM_*)
+    */DAO/              # Database Access Objects (auto-generated from XML)
+    */BAO/              # Business Access Objects (business logic)
+    */Page/             # UI pages
+    */Form/             # Form handlers
+    */Hook/             # Hook implementations
+    */Helper/           # Constants and helper classes
+  Civi/                 # Modern namespace (Civi\*)
+    */Service/          # Business logic services
+    */Utils/            # Utility classes
+    */Helper/           # Traits for shared functionality
+    */Hook/             # Modern hook implementations
+    */Factory/          # Factory classes
+    */Exception/        # Custom exception classes
+  xml/schema/           # Entity schema definitions
+  xml/Menu/             # Menu definitions
+  sql/                  # Database schema and upgrade scripts
+  templates/            # Smarty templates for UI
+  js/                   # JavaScript files
+  css/                  # Stylesheets
+  tests/phpunit/        # PHPUnit tests (mirrors source structure)
+  stubs/                # PHPStan stub files for dynamic classes
+  phpstan.neon          # PHPStan configuration
+  phpcs-ruleset.xml     # PHPCS linting rules
+```
+
+---
+
+## 2. Database Schema Changes
+
+When modifying entities in `xml/schema/`:
+
+```bash
+# In a full CiviCRM dev environment
+civix generate:entity-boilerplate -x /path/to/extension
+```
+
+**Notes:**
+- DAO files are auto-regenerated during extension installation/upgrade
+- Always regenerate DAO files after modifying XML schemas
+- Never edit DAO files manually
+
+---
+
+## 3. Testing Patterns
+
+- Extend `BaseHeadlessTest` for all test classes
+- Use fabricators in `tests/phpunit/Fabricator/` to create test data
+- Mock external API calls where applicable
+- Test positive, negative, and edge cases
+- Store tests mirroring source structure
+
+```php
+class MyServiceTest extends BaseHeadlessTest {
+  public function testSuccessCase(): void {
+    // Arrange
+    $fabricator = new MyEntityFabricator();
+    $entity = $fabricator->fabricate();
+
+    // Act
+    $result = $this->service->process($entity['id']);
+
+    // Assert
+    $this->assertNotNull($result);
+    $this->assertEquals('expected', $result['status']);
+  }
+}
+```

--- a/.ai/shared-development-guide.md
+++ b/.ai/shared-development-guide.md
@@ -1,0 +1,281 @@
+<!-- .ai/shared-development-guide.md v1.5 | Last updated: 2026-02-17 -->
+<!-- Shared development standards for all AI tools and developers. -->
+<!-- Tool-specific instructions: CLAUDE.md, AGENTS.md, GEMINI.md -->
+<!-- Framework-specific: .ai/civicrm.md -->
+
+# Development Standards
+
+---
+
+## 1. Quick Reference
+
+| Resource | Location |
+|----------|----------|
+| Project Overview | [README.md](../README.md) |
+| PR Template | `.github/PULL_REQUEST_TEMPLATE.md` |
+| Linting Rules | `phpcs-ruleset.xml` |
+| CiviCRM Patterns | [.ai/civicrm.md](civicrm.md) |
+| Extension Development | [.ai/extension.md](extension.md) |
+| AI Code Review | [.ai/ai-code-review.md](ai-code-review.md) |
+
+---
+
+## 2. Development Environment
+
+### Running Tests and Linter
+
+```bash
+# Run all tests (requires CiviCRM environment with cv CLI)
+phpunit --configuration phpunit.xml.dist
+
+# Run specific test
+phpunit --configuration phpunit.xml.dist tests/phpunit/path/to/Test.php
+
+# Run linter
+./phpcs.phar --standard=phpcs-ruleset.xml .
+
+# Auto-fix linting issues
+./phpcbf.phar --standard=phpcs-ruleset.xml .
+```
+
+> **Note:** PHPStan is not yet configured for this project. PHPStan sections below are kept as reference for future setup.
+
+---
+
+## 3. Pull Request Guidelines
+
+### PR Title Format
+```
+TICKET-###: Short description
+```
+
+### Required Sections (from template)
+- **Overview**: Non-technical description
+- **Before**: Current state with screenshots/gifs where appropriate
+- **After**: What changed with screenshots/gifs where appropriate
+- **Technical Details**: Noteworthy technical changes, code snippets
+- **Core overrides**: If any CiviCRM core files are patched
+- **Comments**: Any additional notes for reviewers
+
+### When Drafting PRs
+- Reference the ticket ID in the PR title
+- Fill all required template sections
+- Keep summaries factual — avoid assumptions
+- Include before/after screenshots for UI changes
+
+---
+
+## 4. Handling Pull Request Review Feedback
+
+**NEVER blindly implement feedback.** Always think critically and ask questions.
+
+### Required Process
+
+1. **Analyze Each Suggestion:**
+   - Does this suggestion make technical sense?
+   - What are the implications (database constraints, type safety, performance)?
+   - Could this break existing functionality?
+   - Is this consistent with the project's architecture?
+
+2. **Ask Clarifying Questions:**
+   - If unsure about the reasoning, ask: "Why is this change recommended?"
+   - If there are trade-offs, present them: "This suggestion would fix X but might break Y - which is preferred?"
+   - If the suggestion seems incorrect, explain why: "I think this might cause issues because..."
+
+3. **Explain Your Analysis:**
+   - For each change, explain WHY you're making it (or not making it)
+   - Present technical reasoning
+   - Highlight potential issues
+
+4. **Get Approval Before Implementing:**
+   - Show what you plan to change
+   - Wait for explicit confirmation before committing
+   - Never batch commit multiple review changes without review
+
+### Red Flags - Stop and Ask Questions
+- Changes that affect database constraints (NOT NULL, foreign keys)
+- Changes to type checking logic (null checks, empty checks, isset)
+- Suggestions that seem to contradict architectural decisions
+- "Consistency" arguments without technical justification
+- Changes that would alter existing behavior
+- Automated tool suggestions without context
+
+---
+
+## 5. Commit Message Convention
+
+```
+TICKET-###: Short imperative description
+```
+
+**Rules:**
+- Keep under 72 characters
+- Use present tense ("Add", "Fix", "Refactor")
+- Include the correct issue key when committing
+- Be specific and descriptive
+- **DO NOT add any AI attribution or co-authorship lines**
+
+**Examples:**
+```
+TICKET-456: Add null check for membership expiry date
+TICKET-789: Fix fee calculation for recurring contributions
+TICKET-101: Refactor PaymentService to use dependency injection
+```
+
+---
+
+## 6. Code Quality Standards
+
+### Unit Testing
+- **Mandatory** for all new features and bug fixes
+- Never modify or skip tests just to make them pass. Fix the underlying code.
+- Test positive, negative, and edge cases
+- See framework-specific docs for test base classes and patterns
+
+### Linting (PHPCS)
+- Follow project coding standards (`phpcs-ruleset.xml`)
+- All files must end with a newline
+- Run `./phpcbf.phar --standard=phpcs-ruleset.xml .` to auto-fix issues
+
+### Static Analysis (PHPStan)
+
+> **Note:** PHPStan is not yet configured for this project. The following guidelines are kept as reference for when it is set up.
+
+- Never regenerate baseline to "fix" errors - fix the code
+- Goal is to **reduce** the baseline over time, not grow it
+- Use `@phpstan-param` for generic types that linter doesn't support
+
+### PHPStan Baseline Management
+
+- The baseline (`phpstan-baseline.neon`) tracks pre-existing errors
+- **Never add new entries** to work around errors — fix the code or add stubs
+- Regenerate baseline after fixing code
+- `reportUnmatchedIgnoredErrors: false` is set because local and CI scan different paths
+
+### PHPStan CI vs Local Configuration
+
+- **Local**: `phpstan.neon` with Docker paths
+- **CI**: `phpstan-ci.neon` generated in CI workflow with CI paths
+- Both must stay in sync for `level`, `stubFiles`, `excludePaths`, `reportUnmatchedIgnoredErrors`, and `includes`
+- When changing `phpstan.neon`, always check if the CI workflow needs the same change
+
+### Linter + PHPStan Compatibility Pattern
+```php
+/**
+ * @param array $params           // Linter sees this
+ * @phpstan-param array<string, mixed> $params  // PHPStan sees this
+ */
+```
+
+---
+
+## 7. Critical Coding Guidelines
+
+### Security
+- Never log or expose API keys, tokens, or sensitive data
+- Validate all input amounts and parameters before processing
+- Use parameterized queries (prevent SQL injection)
+- Sanitize all user input before rendering (XSS prevention)
+- Verify webhook signatures
+- Ensure proper authentication/authorization for API endpoints
+
+### Performance
+- Identify N+1 query issues
+- Detect inefficient loops or algorithms
+- Avoid unnecessary API calls (use cached records)
+- Recommend caching for expensive operations
+- Review database queries for optimization
+
+### Code Quality
+- Services should follow single responsibility principle
+- Use meaningful, descriptive names
+- Handle exceptions properly (use custom exception classes)
+- All service methods should have proper return type declarations
+- Use dependency injection for service dependencies
+- **Use proper types instead of `mixed`** in PHPDoc annotations
+- **Never use `assert()` in production code** - use proper type checks with exceptions
+
+---
+
+## 8. CI Requirements
+
+All code must pass before merging:
+
+| Check | Command | CI Workflow |
+|-------|---------|-------------|
+| Tests | `phpunit --configuration phpunit.xml.dist` | `tests.yml` |
+| Linting | `./phpcs.phar --standard=phpcs-ruleset.xml .` | `linters.yml` |
+
+---
+
+## 9. Git Discipline
+
+**NEVER use `git add -A` or `git add .`** - always add specific files:
+```bash
+# BAD
+git add -A
+git add .
+
+# GOOD
+git add Civi/Service/MyService.php tests/phpunit/Civi/Service/MyServiceTest.php
+```
+
+**Always run linter before committing:**
+```bash
+./phpcs.phar --standard=phpcs-ruleset.xml .
+git add <specific-files>
+git commit -m "TICKET-###: Description"
+```
+
+**Always run tests before committing code changes:**
+- When modifying source files, run `phpunit --configuration phpunit.xml.dist` BEFORE committing
+- When modifying error messages, verify affected tests expect the new message
+
+---
+
+## 10. Safety Rules
+
+- Never commit code without running **tests** and **linting**
+- Never remove or weaken tests to make them pass
+- Never push commits automatically without human review
+- If unsure, stop and consult a senior developer
+
+### Sensitive Files (Never Commit)
+- `civicrm.settings.php` (contains API keys)
+- `.env` files
+- Any files with credentials or secrets
+
+### Auto-Generated Files (Do Not Edit Manually)
+- `*.civix.php` (regenerate with `civix`)
+- `CRM/*/DAO/*.php` (regenerate from XML schemas)
+- Files in `xml/schema/*.entityType.php` (auto-generated)
+
+---
+
+## 11. Pre-Merge Validation Checklist
+
+| Check | Requirement |
+|-------|-------------|
+| Tests pass | All green in CI |
+| Linting passes | No violations |
+| Commit prefix | Uses TICKET-### format |
+| PR template used | `.github/PULL_REQUEST_TEMPLATE.md` completed |
+| No sensitive data | No API keys or credentials in code |
+| Code reviewed | At least one approval from team member |
+
+---
+
+## 12. Common Commands
+
+```bash
+# Git
+git status && git diff
+
+# Testing
+phpunit --configuration phpunit.xml.dist              # Run all tests
+phpunit --configuration phpunit.xml.dist path/to/Test.php  # Run specific test
+
+# Code Quality
+./phpcs.phar --standard=phpcs-ruleset.xml .   # Check linting
+./phpcbf.phar --standard=phpcs-ruleset.xml .  # Auto-fix linting
+```

--- a/.ai/unit-testing-guide.md
+++ b/.ai/unit-testing-guide.md
@@ -1,0 +1,489 @@
+<!-- .ai/unit-testing-guide.md v1.0 | Last updated: 2026-02-17 -->
+
+# Unit Testing Guide
+
+A practical guide for when to write tests, what to test, and how to write effective tests for CiviCRM extensions.
+
+---
+
+## 1. When to Write Tests
+
+### Always Write Tests For
+
+| Scenario | Why |
+|----------|-----|
+| **New features** | Proves the feature works as designed |
+| **Bug fixes** | Prevents the bug from reoccurring |
+| **Business logic** | Services, calculations, decision trees |
+| **API endpoints** | Validates input/output contracts |
+| **Data transformations** | Ensures data integrity |
+| **Edge cases you discover** | Documents known gotchas |
+
+### Test Coverage Priority
+
+```
+High Priority (Must Test)
+├── Payment processing logic
+├── Financial calculations
+├── Webhook handlers
+├── Data migrations / imports
+├── Security-sensitive code
+└── Complex business rules
+
+Medium Priority (Should Test)
+├── API wrappers
+├── Form validation
+├── Status transitions
+└── Configuration handling
+
+Lower Priority (Nice to Have)
+├── Simple getters/setters
+├── UI display logic
+└── Logging
+```
+
+---
+
+## 2. What Tests Should Cover
+
+### The Three Cases Rule
+
+Every test should cover at minimum:
+
+1. **Positive case** — Happy path, expected input produces expected output
+2. **Negative case** — Invalid input is handled gracefully (exceptions, error messages)
+3. **Edge case** — Boundary conditions, empty values, nulls, limits
+
+### Example: Testing a Payment Amount Validator
+
+```php
+class PaymentAmountValidatorTest extends BaseHeadlessTest {
+
+  /**
+   * Positive case: Valid amount is accepted.
+   */
+  public function testValidAmountIsAccepted(): void {
+    $validator = new PaymentAmountValidator();
+
+    $result = $validator->validate(100.00, 'GBP');
+
+    $this->assertTrue($result->isValid());
+  }
+
+  /**
+   * Negative case: Zero amount is rejected.
+   */
+  public function testZeroAmountIsRejected(): void {
+    $validator = new PaymentAmountValidator();
+
+    $result = $validator->validate(0, 'GBP');
+
+    $this->assertFalse($result->isValid());
+    $this->assertEquals('Amount must be greater than zero', $result->getError());
+  }
+
+  /**
+   * Negative case: Negative amount is rejected.
+   */
+  public function testNegativeAmountIsRejected(): void {
+    $validator = new PaymentAmountValidator();
+
+    $result = $validator->validate(-50.00, 'GBP');
+
+    $this->assertFalse($result->isValid());
+  }
+
+  /**
+   * Edge case: Very small amount (minimum threshold).
+   */
+  public function testMinimumAmountThreshold(): void {
+    $validator = new PaymentAmountValidator();
+
+    // 0.01 is the minimum valid amount
+    $result = $validator->validate(0.01, 'GBP');
+
+    $this->assertTrue($result->isValid());
+  }
+
+  /**
+   * Edge case: Amount with many decimal places is rounded.
+   */
+  public function testAmountIsRoundedToTwoDecimals(): void {
+    $validator = new PaymentAmountValidator();
+
+    $result = $validator->validate(99.999, 'GBP');
+
+    $this->assertTrue($result->isValid());
+    $this->assertEquals(100.00, $result->getNormalizedAmount());
+  }
+}
+```
+
+---
+
+## 3. Test Structure: Arrange-Act-Assert
+
+Every test should follow this pattern:
+
+```php
+public function testSomething(): void {
+  // Arrange - Set up test data and dependencies
+  $fabricator = new ContributionFabricator();
+  $contribution = $fabricator->fabricate(['total_amount' => 100]);
+
+  // Act - Execute the code under test
+  $result = $this->service->processRefund($contribution['id'], 50);
+
+  // Assert - Verify the expected outcome
+  $this->assertTrue($result->isSuccess());
+  $this->assertEquals(50, $result->getRefundedAmount());
+}
+```
+
+### Good vs Bad Test Names
+
+```php
+// BAD - Vague, doesn't describe the scenario
+public function testProcess(): void { }
+public function testValidation(): void { }
+public function test1(): void { }
+
+// GOOD - Describes scenario and expected outcome
+public function testProcessRefundCreatesFinancialTransaction(): void { }
+public function testValidationFailsWhenAmountExceedsBalance(): void { }
+public function testWebhookIsIgnoredWhenAlreadyProcessed(): void { }
+```
+
+---
+
+## 4. Testing CiviCRM Extensions
+
+### Base Test Class
+
+Always extend `BaseHeadlessTest` for CiviCRM extension tests:
+
+```php
+namespace Civi\MyExtension\Test\Service;
+
+use Civi\MyExtension\Test\BaseHeadlessTest;
+
+class MyServiceTest extends BaseHeadlessTest {
+
+  private MyService $service;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->service = new MyService();
+  }
+}
+```
+
+### Using Fabricators
+
+Use fabricators to create test data consistently:
+
+```php
+// tests/phpunit/Fabricator/ContributionFabricator.php
+class ContributionFabricator {
+
+  /**
+   * @phpstan-var array<string, string|int>
+   */
+  protected static array $defaultParams = [
+    'financial_type_id' => 'Donation',
+    'total_amount' => 100,
+    'contribution_status_id:name' => 'Completed',
+  ];
+
+  /**
+   * @param array $params Override default values
+   * @return array The created contribution
+   */
+  public function fabricate(array $params = []): array {
+    $result = \Civi\Api4\Contribution::create(FALSE)
+      ->setValues(array_merge(self::$defaultParams, $params))
+      ->execute()
+      ->first();
+
+    if (!is_array($result)) {
+      throw new \RuntimeException('Failed to create test contribution');
+    }
+
+    return $result;
+  }
+}
+```
+
+### Testing API4 Results
+
+Always guard against null/non-array results:
+
+```php
+public function testGetContributionReturnsExpectedData(): void {
+  // Arrange
+  $fabricator = new ContributionFabricator();
+  $created = $fabricator->fabricate(['total_amount' => 250]);
+
+  // Act
+  $result = \Civi\Api4\Contribution::get(FALSE)
+    ->addSelect('id', 'total_amount')
+    ->addWhere('id', '=', $created['id'])
+    ->execute()
+    ->first();
+
+  // Assert - Guard against null before accessing
+  $this->assertNotNull($result);
+  $this->assertIsArray($result);
+  $this->assertEquals(250, $result['total_amount']);
+}
+```
+
+---
+
+## 5. Testing Webhooks and External APIs
+
+### Mock External Services
+
+Never call real external APIs in tests. Use mocks:
+
+```php
+class StripeWebhookHandlerTest extends BaseHeadlessTest {
+
+  private StripeWebhookHandler $handler;
+  private MockStripeClient $mockClient;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->mockClient = new MockStripeClient();
+    $this->handler = new StripeWebhookHandler($this->mockClient);
+  }
+
+  public function testPaymentIntentSucceededUpdatesContribution(): void {
+    // Arrange
+    $contribution = $this->createPendingContribution();
+
+    $webhookPayload = [
+      'type' => 'payment_intent.succeeded',
+      'data' => [
+        'object' => [
+          'id' => 'pi_test_123',
+          'amount' => 10000, // £100.00 in pence
+          'metadata' => ['contribution_id' => $contribution['id']],
+        ],
+      ],
+    ];
+
+    // Act
+    $result = $this->handler->handle($webhookPayload);
+
+    // Assert
+    $this->assertEquals('applied', $result);
+
+    $updated = $this->getContribution($contribution['id']);
+    $this->assertEquals('Completed', $updated['contribution_status_id:name']);
+  }
+
+  public function testDuplicateWebhookIsIgnored(): void {
+    // Arrange
+    $contribution = $this->createCompletedContribution();
+
+    $webhookPayload = [
+      'type' => 'payment_intent.succeeded',
+      'data' => [
+        'object' => [
+          'id' => 'pi_test_123',
+          'metadata' => ['contribution_id' => $contribution['id']],
+        ],
+      ],
+    ];
+
+    // Act - Process same webhook twice
+    $this->handler->handle($webhookPayload);
+    $result = $this->handler->handle($webhookPayload);
+
+    // Assert - Second call is a no-op
+    $this->assertEquals('noop', $result);
+  }
+}
+```
+
+### Test Idempotency
+
+Webhook handlers should be idempotent — processing the same event twice should not cause issues:
+
+```php
+public function testWebhookHandlerIsIdempotent(): void {
+  $payload = $this->createTestWebhookPayload();
+
+  // Process twice
+  $result1 = $this->handler->handle($payload);
+  $result2 = $this->handler->handle($payload);
+
+  // First should apply, second should be noop
+  $this->assertEquals('applied', $result1);
+  $this->assertEquals('noop', $result2);
+
+  // Verify only one contribution created
+  $contributions = $this->getContributionsByExternalId($payload['id']);
+  $this->assertCount(1, $contributions);
+}
+```
+
+---
+
+## 6. Testing Error Handling
+
+### Test That Exceptions Are Thrown
+
+```php
+public function testInvalidCurrencyThrowsException(): void {
+  $this->expectException(\CRM_Core_Exception::class);
+  $this->expectExceptionMessage('Unsupported currency: XYZ');
+
+  $this->service->processPayment(100, 'XYZ');
+}
+```
+
+### Test Error Messages
+
+When error messages are user-facing, test them explicitly:
+
+```php
+public function testValidationErrorMessageIsUserFriendly(): void {
+  try {
+    $this->service->processPayment(-100, 'GBP');
+    $this->fail('Expected exception was not thrown');
+  } catch (\CRM_Core_Exception $e) {
+    // Assert message is user-friendly, not technical
+    $this->assertStringNotContainsString('Exception', $e->getMessage());
+    $this->assertStringNotContainsString('NULL', $e->getMessage());
+    $this->assertStringContainsString('amount', strtolower($e->getMessage()));
+  }
+}
+```
+
+---
+
+## 7. Test Data Cleanup
+
+### Use Transactions (Preferred)
+
+The `BaseHeadlessTest` should roll back database changes after each test:
+
+```php
+abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase
+  implements \Civi\Test\HeadlessInterface {
+
+  public function setUpHeadless(): \Civi\Test\CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  // Each test runs in a transaction that gets rolled back
+}
+```
+
+### Manual Cleanup When Needed
+
+If transactions don't work for your test, clean up manually:
+
+```php
+private array $createdContributionIds = [];
+
+protected function tearDown(): void {
+  foreach ($this->createdContributionIds as $id) {
+    \Civi\Api4\Contribution::delete(FALSE)
+      ->addWhere('id', '=', $id)
+      ->execute();
+  }
+  parent::tearDown();
+}
+```
+
+---
+
+## 8. Anti-Patterns to Avoid
+
+### Don't Test Implementation Details
+
+```php
+// BAD - Tests internal method call order
+public function testProcessCallsValidateThenSave(): void {
+  $mock = $this->createMock(Service::class);
+  $mock->expects($this->exactly(1))->method('validate');
+  $mock->expects($this->exactly(1))->method('save');
+}
+
+// GOOD - Tests observable behavior
+public function testProcessSavesValidData(): void {
+  $result = $this->service->process($validData);
+
+  $this->assertTrue($result->isSaved());
+  $this->assertDatabaseHas('civicrm_contribution', ['id' => $result->getId()]);
+}
+```
+
+### Don't Weaken Tests to Make Them Pass
+
+```php
+// BAD - Removing assertion to "fix" failing test
+public function testCalculateTotal(): void {
+  $result = $this->service->calculateTotal([100, 200]);
+  // $this->assertEquals(300, $result);  // Commented out because it fails
+}
+
+// GOOD - Fix the code, not the test
+public function testCalculateTotal(): void {
+  $result = $this->service->calculateTotal([100, 200]);
+  $this->assertEquals(300, $result);
+}
+```
+
+### Don't Use Sleep in Tests
+
+```php
+// BAD - Slow and unreliable
+public function testAsyncProcess(): void {
+  $this->service->startAsync();
+  sleep(5); // Wait for completion
+  $this->assertTrue($this->service->isComplete());
+}
+
+// GOOD - Use polling with timeout or mock the async behavior
+public function testAsyncProcess(): void {
+  $mockQueue = $this->createMock(QueueService::class);
+  $mockQueue->expects($this->once())->method('enqueue');
+
+  $this->service->startAsync();
+  // Test that it was enqueued, not that it completed
+}
+```
+
+---
+
+## 9. Running Tests
+
+```bash
+# Run all tests
+phpunit --configuration phpunit.xml.dist
+
+# Run specific test file
+phpunit --configuration phpunit.xml.dist tests/phpunit/Civi/MyExtension/Service/MyServiceTest.php
+
+# Run specific test method
+phpunit --configuration phpunit.xml.dist --filter testValidAmountIsAccepted
+```
+
+---
+
+## 10. Checklist Before Committing
+
+- [ ] All new code has corresponding tests
+- [ ] Tests cover positive, negative, and edge cases
+- [ ] Test names clearly describe the scenario
+- [ ] No `sleep()` calls in tests
+- [ ] No hardcoded IDs or dates that will break later
+- [ ] External APIs are mocked, not called directly
+- [ ] Tests run in isolation (no dependency on other tests)
+- [ ] All tests pass locally: `phpunit --configuration phpunit.xml.dist`

--- a/.claude/commands/pre-commit.md
+++ b/.claude/commands/pre-commit.md
@@ -1,0 +1,10 @@
+Check my changes are ready to commit.
+
+1. Run `git diff --cached` to see staged changes
+2. Verify commit message follows `TICKET-###:` format
+3. Check for sensitive files (civicrm.settings.php, .env)
+4. Check for auto-generated files that shouldn't be edited manually
+5. Verify files end with newlines
+6. Flag any issues before committing
+
+$ARGUMENTS

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,11 @@
+Review my current changes against the project coding standards.
+
+The user may provide a base branch name as an argument. If not provided, ask which base branch to diff against before proceeding.
+
+1. Run `git diff <base-branch>...HEAD` to see all committed changes on this branch
+2. Also run `git diff` and `git diff --cached` to catch any uncommitted/staged changes
+3. Apply the review checklist from .ai/ai-code-review.md
+4. Flag issues by severity: BLOCKER, WARNING, SUGGESTION, QUESTION
+5. Reference specific file paths and line numbers
+
+$ARGUMENTS

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Git status)",
+      "Bash(Git diff*)",
+      "Bash(Git log*)",
+      "Bash(Git branch*)",
+      "Bash(phpunit *)",
+      "Bash(./phpcs.phar *)",
+      "Bash(./phpcbf.phar *)"
+    ],
+    "deny": [
+      "Bash(Git push*)",
+      "Bash(Git reset --hard*)",
+      "Bash(Rm -rf*)"
+    ]
+  }
+}

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,41 @@
+# Gemini Code Assist configuration
+# See: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
+
+# Files/directories Gemini should ignore during review
+ignore_patterns:
+  - "*.civix.php"
+  - "CRM/*/DAO/*.php"
+  - "xml/schema/*.entityType.php"
+  - "vendor/**"
+  - "node_modules/**"
+  - "*.min.js"
+  - "*.min.css"
+
+# Persistent memory for this repository (learns from past reviews)
+memory_config:
+  disabled: false
+
+# Code review settings
+code_review:
+  # Set to true to disable Gemini on PRs
+  disable: false
+
+  # Minimum severity for review comments (LOW, MEDIUM, HIGH, CRITICAL)
+  comment_severity_threshold: MEDIUM
+
+  # Maximum number of review comments (-1 for unlimited)
+  max_review_comments: -1
+
+  # What happens when a PR is opened
+  pull_request_opened:
+    # Post a help message explaining how to interact with Gemini
+    help: false
+
+    # Post a PR summary (overview of changes)
+    summary: true
+
+    # Post code review comments
+    code_review: true
+
+    # Also review draft PRs
+    include_drafts: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,56 @@
+# Code Review Style Guide
+
+This style guide defines how Gemini Code Assist should review Pull Requests.
+
+## Standards
+
+Follow all standards in [.ai/shared-development-guide.md](../.ai/shared-development-guide.md).
+
+For CiviCRM extensions, also follow [.ai/civicrm.md](../.ai/civicrm.md) and [.ai/extension.md](../.ai/extension.md).
+
+For the full review checklist and severity definitions, see [.ai/ai-code-review.md](../.ai/ai-code-review.md).
+
+## Review Focus
+
+### Must Check (BLOCKER if violated)
+- No hardcoded secrets, API keys, or credentials in code
+- No SQL injection (use parameterized queries)
+- No XSS (sanitize user input before rendering)
+- Webhook signatures verified
+- No auto-generated files edited manually (`*.civix.php`, `CRM/*/DAO/*.php`)
+- No sensitive files committed (`civicrm.settings.php`, `.env`)
+- Tests not removed or weakened to pass
+
+### Should Check (WARNING)
+- Commit messages follow `TICKET-###:` format
+- New features and bug fixes include unit tests
+- PHPStan level 9 compliance (proper types, no `mixed` where avoidable)
+- `is_array()` guard on API4 `->first()` results
+- `@phpstan-param` / `@phpstan-var` used where linter and PHPStan conflict
+- No `assert()` in production code
+- No N+1 query issues
+- Services follow single responsibility principle
+- Dependency injection used for service dependencies
+- No AI attribution in commits
+
+### Nice to Have (SUGGESTION)
+- Code readability improvements
+- Better variable naming
+- Additional edge case test coverage
+- Documentation improvements
+
+## Severity Labels
+
+Use these in review comments:
+- **BLOCKER**: Must fix before merge (security, data loss, broken functionality)
+- **WARNING**: Should fix (quality, performance, maintainability)
+- **SUGGESTION**: Optional improvement
+- **QUESTION**: Needs clarification from the author
+
+## Review Style
+
+- Be specific -- reference file paths and line numbers
+- Explain **why** something is an issue, not just what to change
+- Think critically -- don't suggest changes that contradict architectural decisions
+- Consider implications of type changes, database constraints, performance trade-offs
+- Distinguish severity clearly -- not everything is a blocker

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+<!-- copilot-pr-review.md v1.1 | Last updated: 2026-02-17 -->
+
+# GitHub Copilot PR Review Guide
+
+This file defines how **GitHub Copilot** assists in pull request reviews for this repository.
+Copilot must follow our engineering standards, CI workflows, and commit conventions when reviewing code.
+
+---
+
+## 1. Review Objectives
+
+Copilot should:
+
+- Verify code quality, readability, and maintainability
+- Confirm compliance with CI (PHPUnit, Linters)
+- Ensure PRs follow commit, testing, and documentation guidelines
+- Never auto-approve — only provide actionable feedback
+
+---
+
+## 2. Pull Request Format
+
+All PRs must follow `.github/PULL_REQUEST_TEMPLATE.md`.
+
+**Checklist:**
+
+- PR title includes issue key (e.g., `TICKET-123: Fix summary bug`)
+- All template sections (Problem, Solution, Testing) are completed
+- Linked to correct issue
+
+If incomplete, Copilot should suggest precise edits or missing fields.
+
+---
+
+## 3. Review Checklist
+
+| Category        | Requirement                          | Example Feedback                                                   |
+|----------------|--------------------------------------|---------------------------------------------------------------------|
+| **Code Quality** | Clear, maintainable logic             | "Consider extracting this logic into a helper."                     |
+| **Testing**     | PHPUnit tests included and passing   | "Missing test for `MembershipService::validate()`."                |
+| **Style**       | Follows PSR-12 & naming conventions  | "Rename `$obj` → `$contactData` for clarity."                      |
+| **Docs**        | Public methods include PHPDoc        | "Add PHPDoc for `InvoiceHandler::calculateTotals()`."              |
+
+---
+
+## 4. Critical Review Areas
+
+### Security
+
+- Detect hardcoded secrets or API keys
+- Check for SQL injection and XSS
+- Validate user input & sanitize output
+- Review authentication/authorization logic
+
+### Performance
+
+- Identify N+1 query issues
+- Detect inefficient loops or algorithms
+- Spot memory leaks or unfreed resources
+- Recommend caching for expensive ops
+
+### Code Quality
+
+- Functions should be focused and testable
+- Use meaningful, descriptive names
+- Handle errors properly
+
+---
+
+## 5. Review Style Tips
+
+- Be specific and actionable
+- Explain the "why" behind your suggestions
+- Acknowledge good patterns
+- Ask clarifying questions if intent is unclear

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- AGENTS.md v1.5 | Last updated: 2026-02-17 -->
+
+# Codex Development Guide
+
+> **Shared standards:** Read [.ai/shared-development-guide.md](.ai/shared-development-guide.md) for all coding standards, CI requirements, commit conventions, and best practices.
+>
+> **CiviCRM reference:** See [.ai/civicrm.md](.ai/civicrm.md) for CiviCRM core patterns and [.ai/extension.md](.ai/extension.md) for extension structure and testing.
+>
+> **Code review:** See [.ai/ai-code-review.md](.ai/ai-code-review.md) for review checklist and process.
+
+This file contains **Codex-specific** instructions only.
+
+---
+
+## Codex Environment Constraints
+
+Codex runs in a **sandboxed environment** with limited capabilities:
+
+- No network access during execution
+- Cannot run Docker commands
+- Cannot access CI workflows directly
+- Can read all files in the repository
+- Can write and modify files
+
+---
+
+## Codex-Specific Rules
+
+- **DO NOT add any AI attribution** to commits
+- Follow the `TICKET-###:` commit format from the shared guide
+- Since you cannot run tests, ensure code is correct by careful analysis
+- Write tests alongside code changes
+- Always flag verification steps the developer must run
+
+---
+
+## Codex Workflow
+
+1. **Plan** -- Outline the approach before making changes
+2. **Edit** -- Apply changes following all shared standards
+3. **Flag** -- Note what the developer must verify
+
+### Always Remind the Developer To
+```bash
+phpunit --configuration phpunit.xml.dist       # Run tests before committing
+./phpcs.phar --standard=phpcs-ruleset.xml .    # Check linting before committing
+```
+
+---
+
+## Codex for Code Review
+
+Codex can review code changes using the process in [.ai/ai-code-review.md](.ai/ai-code-review.md):
+
+- Feed `git diff master...HEAD` output for pre-push review
+- Review PRs when integrated with GitHub
+- Apply the same checklist and severity levels as any other tool
+- **Never auto-approve** -- provide actionable feedback
+- Think critically about suggestions (shared guide, Section 4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+<!-- CLAUDE.md v1.5 | Last updated: 2026-02-17 -->
+
+# Claude Code Instructions
+
+> **Shared standards:** Read [.ai/shared-development-guide.md](.ai/shared-development-guide.md) for all coding standards, CI requirements, commit conventions, and best practices.
+>
+> **CiviCRM reference:** See [.ai/civicrm.md](.ai/civicrm.md) for CiviCRM core patterns and [.ai/extension.md](.ai/extension.md) for extension structure and testing.
+>
+> **Code review:** See [.ai/ai-code-review.md](.ai/ai-code-review.md) for review checklist and process.
+
+This file contains **Claude Code-specific** instructions plus project-specific architecture context.
+
+---
+
+## Overview
+
+This is a CiviCRM extension that provides the `MembershipextrasImporter` API endpoint for importing payment plan membership orders via CSV. It's designed to work with the CSV Importer extension (nz.co.fuzion.csvimport) and the Membershipextras extension (uk.co.compucorp.membershipextras).
+
+## Commands
+
+### Linting
+
+```bash
+# Install linting tools (first time setup)
+bin/install-php-linter
+
+# Run PHPCS
+./phpcs.phar --standard=phpcs-ruleset.xml .
+
+# Auto-fix with PHPCBF
+./phpcbf.phar --standard=phpcs-ruleset.xml .
+```
+
+### Testing
+
+Tests require a CiviCRM environment with the `cv` CLI tool available:
+
+```bash
+# Run all tests
+phpunit --configuration phpunit.xml.dist
+
+# Run a specific test file
+phpunit --configuration phpunit.xml.dist tests/phpunit/CRM/Membershipextrasimporterapi/EntityImporter/ContributionTest.php
+
+# Run a specific test method
+phpunit --configuration phpunit.xml.dist --filter testMethodName
+```
+
+Tests extend `BaseHeadlessTest` which installs required extensions: membershipextras, manualdirectdebit, automateddirectdebit, and financeextras.
+
+---
+
+## Claude Code Workflow
+
+### Plan Mode and Execution Mode
+
+1. **Explain** -- Ask Claude to describe the issue in its own words
+2. **Plan** -- Use Plan Mode (`Shift + Tab` twice) for complex tasks
+3. **Review** -- Verify and edit the plan before implementation
+4. **Implement** -- Disable Plan Mode and apply changes
+5. **Verify** -- Run tests and linting
+
+### Request Confirmation Before
+- Deleting or overwriting files
+- Database migrations
+- Modifying auto-generated files (see shared guide, Section 10)
+
+---
+
+## Environment Constraints
+
+- Cannot run tests or PHPStan directly without CiviCRM environment
+- Can write test files following existing patterns
+- Can fix errors based on CI output
+- Suggest: "Push changes to trigger CI" or "Run tests locally with cv"
+
+---
+
+## Claude-Specific Rules
+
+- **DO NOT add `Co-Authored-By: Claude` or any AI attribution** to commits
+- Never push commits automatically without human review
+- When proposing commits, use the `TICKET-###:` format from the shared guide
+- Always read files before editing them
+
+---
+
+## Pre-Push Self-Review
+
+Before proposing a commit, Claude can review its own changes in the same session:
+
+```bash
+# Replace <base-branch> with your PR target (master, main, develop, etc.)
+git diff <base-branch>...HEAD
+```
+
+For unbiased review, use a **separate Claude session** and follow [.ai/ai-code-review.md](.ai/ai-code-review.md).
+
+---
+
+## Architecture
+
+### Import Flow
+
+The API endpoint `MembershipextrasImporter.create` is the entry point (`api/v3/MembershipextrasImporter.php`). Each CSV row triggers `CSVRowImporter::import()` which orchestrates entity creation in this order within a database transaction:
+
+1. **RecurContribution** - Creates the payment plan (recurring contribution)
+2. **Membership** - Creates membership linked to the payment plan
+3. **Contribution** - Creates individual contribution record
+4. **MembershipPayment** - Links membership to contribution
+5. **LineItem** - Creates line items with financial records
+6. **ManualDirectDebitMandate** - Creates DD mandate if using Manual DD extension
+7. **ExternalDirectDebitMandate** - Creates external DD mandate if applicable
+
+### Key Design Patterns
+
+- **Entity Importers** (`CRM/Membershipextrasimporterapi/EntityImporter/`): Each entity type has its own importer class that handles creation and lookup by external ID
+- **External ID Tracking**: Entities use external IDs stored in custom fields (e.g., `civicrm_value_contribution_ext_id`) to enable idempotent imports and updates
+- **Raw SQL Performance**: Uses direct SQL via `SQLQueryRunner` instead of CiviCRM API for performance during bulk imports
+- **Transaction Wrapping**: Each row import is wrapped in a transaction for atomicity
+
+### Directory Structure
+
+- `api/v3/` - CiviCRM API v3 endpoint definition with parameter specs
+- `Civi/Api4/` - CiviCRM API v4 entity definition
+- `CRM/Membershipextrasimporterapi/EntityImporter/` - Entity-specific import logic
+- `CRM/Membershipextrasimporterapi/EntityCreator/` - Entity creation helpers
+- `CRM/Membershipextrasimporterapi/Exception/` - Custom exceptions for validation errors
+
+### Required Extensions
+
+- `uk.co.compucorp.membershipextras` - Payment plan membership support
+- `nz.co.fuzion.csvimport` - CSV import mechanism
+- `uk.co.compucorp.manualdirectdebit` - Optional, for Direct Debit mandates
+- `io.compuco.financeextras` - Optional, for multi-company accounting
+
+---
+
+## Developer Prompts (Examples)
+
+| Task | Prompt |
+|------|--------|
+| Generate tests | "Create PHPUnit tests for `PaymentHandler::process()` covering success and error cases." |
+| Summarize PR | "Summarize commits into PR description using template for TICKET-123." |
+| Fix linting | "Fix PHPCS violations in `ContributionService.php`." |
+| Review changes | "Review my changes against our coding standards: `git diff master...HEAD`" |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,44 @@
+<!-- GEMINI.md v1.5 | Last updated: 2026-02-17 -->
+
+# Gemini Instructions
+
+> **Shared standards:** Read [.ai/shared-development-guide.md](.ai/shared-development-guide.md) for all coding standards, CI requirements, commit conventions, and best practices.
+>
+> **CiviCRM reference:** See [.ai/civicrm.md](.ai/civicrm.md) for CiviCRM core patterns and [.ai/extension.md](.ai/extension.md) for extension structure and testing.
+>
+> **Code review:** See [.ai/ai-code-review.md](.ai/ai-code-review.md) for the full review checklist, severity levels, and process.
+
+This file contains **Gemini-specific** instructions only.
+
+---
+
+## Gemini's Primary Role
+
+Gemini is used for **code review** -- both pre-push (developer-initiated) and on GitHub PRs. It can also assist with development.
+
+---
+
+## Pre-Push Review (Any Interface)
+
+Developers can request review before pushing, using any Gemini interface (IDE extension, web, CLI). Follow the process in [.ai/ai-code-review.md](.ai/ai-code-review.md).
+
+---
+
+## GitHub PR Review
+
+When reviewing PRs on GitHub, Gemini should:
+
+- Apply the full checklist from [.ai/ai-code-review.md](.ai/ai-code-review.md)
+- Post comments on specific lines with severity labels
+- **Never auto-approve** -- provide actionable feedback
+- Think critically (shared guide, Section 4)
+
+---
+
+## Gemini-Specific Rules
+
+- **DO NOT add any AI attribution** to commits if writing code
+- Follow the `TICKET-###:` commit format from the shared guide
+- When reviewing, distinguish clearly between BLOCKERs and SUGGESTIONs
+- Be specific -- reference file paths and line numbers
+- Explain **why** something is an issue, not just what to change


### PR DESCRIPTION
## Overview

Adds cross-tool AI development playbooks (Claude Code, Gemini Code Assist, OpenAI Codex) with shared coding standards, code review processes, and tool-specific configurations. Adapted from the `dev-ai-playbooks` repo with project-specific commands and conventions.

## Before

Only a basic `CLAUDE.md` existed. No shared AI standards, no Gemini/Codex configuration, no code review guides.

## After

14 files providing a complete AI-assisted development framework:

**Shared standards (`.ai/`):**
- `shared-development-guide.md` — Coding standards, CI requirements, commit conventions, git discipline
- `ai-code-review.md` — Tool-agnostic code review checklist and process
- `civicrm.md` — CiviCRM core patterns (API4, hooks, services)
- `extension.md` — Extension structure, schema management, testing patterns
- `unit-testing-guide.md` — When/what/how to test, anti-patterns

**Claude Code (`.claude/`):**
- `settings.json` — Permission allow/deny for CLI commands
- `commands/review.md` — `/review` slash command for pre-push review
- `commands/pre-commit.md` — `/pre-commit` slash command

**Gemini (`.gemini/`):**
- `config.yaml` — PR review settings, ignore patterns
- `styleguide.md` — Review focus areas and severity labels

**Tool entry points:**
- `CLAUDE.md` — Updated with playbook structure + existing architecture docs
- `AGENTS.md` — Codex-specific instructions
- `GEMINI.md` — Gemini-specific instructions
- `.github/copilot-instructions.md` — GitHub Copilot PR review guide

## Technical Details

- All `./scripts/run.sh` commands replaced with direct project commands (`phpunit`, `./phpcs.phar`, `./phpcbf.phar`)
- Commit prefix uses generic `TICKET-###:` placeholder (varies by project)
- PHPStan sections kept as reference but noted as not yet configured
- CI table references actual `tests.yml` and `linters.yml` workflows
- Existing `CLAUDE.md` architecture content (import flow, design patterns, directory structure) preserved

## Core overrides

None.

## Comments

- `.github/workflows/` and `.github/PULL_REQUEST_TEMPLATE.md` were intentionally NOT modified
- PHPStan setup is excluded (separate initiative)
- No PHP files were changed